### PR TITLE
feat: start translation job in background

### DIFF
--- a/web/app/routes/translate/components/URLTranslationForm.tsx
+++ b/web/app/routes/translate/components/URLTranslationForm.tsx
@@ -8,12 +8,15 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { urlTranslationSchema } from "../types";
 import { AIModelSelector } from "./AIModelSelector";
+import type { action } from "../route";
+import { useTypedActionData } from "remix-typedjson";
 
 export function URLTranslationForm() {
 	const navigation = useNavigation();
 	const [selectedModel, setSelectedModel] = useState("gemini-1.5-flash");
-
+	const actionData = useTypedActionData<typeof action>();
 	const [form, fields] = useForm({
+		lastResult: actionData?.lastResult,
 		id: "url-translation-form",
 		constraint: getZodConstraint(urlTranslationSchema),
 		shouldValidate: "onBlur",
@@ -51,6 +54,14 @@ export function URLTranslationForm() {
 					</Button>
 				</div>
 			</Form>
+
+			{actionData?.intent === "translateUrl" && actionData?.url && (
+				<div className="bg-gray-800 p-4 rounded-lg">
+					<p className="text-white">
+						Translation job started for <strong>{actionData.url}</strong>
+					</p>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/web/app/routes/translate/translate-job.server.ts
+++ b/web/app/routes/translate/translate-job.server.ts
@@ -1,0 +1,32 @@
+import { fetchWithRetry } from "../../feature/translate/utils/fetchWithRetry";
+import { extractArticle } from "../../feature/translate/utils/extractArticle";
+import { addNumbersToContent } from "../../feature/translate/utils/addNumbersToContent";
+import { extractNumberedElements } from "../../feature/translate/utils/extractNumberedElements";
+import { translate } from "../../feature/translate/libs/translation";
+
+interface TranslateJobParams {
+	url: string;
+	targetLanguage: string;
+	apiKey: string;
+	userId: number;
+}
+export const translateJob = async (params: TranslateJobParams) => {
+	const html = await fetchWithRetry(params.url);
+	const { content, title } = extractArticle(html, params.url);
+	const numberedContent = addNumbersToContent(content);
+	const extractedNumberedElements = extractNumberedElements(
+		numberedContent,
+		title,
+	);
+	const targetLanguage = params.targetLanguage;
+
+	await translate(
+		params.apiKey,
+		params.userId,
+		targetLanguage,
+		title,
+		numberedContent,
+		extractedNumberedElements,
+		params.url,
+	);
+};

--- a/web/app/routes/translate/types.ts
+++ b/web/app/routes/translate/types.ts
@@ -5,6 +5,7 @@ export const geminiApiKeySchema = z.object({
 });
 
 export const urlTranslationSchema = z.object({
+	intent: z.literal("translateUrl"),
 	url: z
 		.string()
 		.min(1, { message: "URLを入力してください" })


### PR DESCRIPTION
翻訳処理をバックグラウンドで処理するようにします。
translate route ではすでに5秒毎にジョブのステータス更新がされている状況だったので、
翻訳処理部分を async 関数に切り出してそれを await しないで呼び出すだけにしています。

https://github.com/user-attachments/assets/0ee14f76-6a8c-4446-83a3-e50f26909f36

翻訳処理開始を通知したかったので、Action Data で URL 戻すようにしました。
それに合わせて型を合わせるため他の intent の戻り値も submission.reply() を lastResult にいれるようにしました。ついでに {resetForm: true} も入れて翻訳開始とともにフォームをリセットするようにしました。

