### PR TITLE
geminiエラーの表示

### DIFF
--- a/web/app/routes/translate/components/GeminiApiKeyForm.tsx
+++ b/web/app/routes/translate/components/GeminiApiKeyForm.tsx
@@ -1,6 +1,5 @@
 import { useForm } from "@conform-to/react";
 import { getFormProps, getInputProps } from "@conform-to/react";
-import type { SubmissionResult } from "@conform-to/react";
 import { getZodConstraint, parseWithZod } from "@conform-to/zod";
 import { Form, useActionData } from "@remix-run/react";
 import { Link } from "@remix-run/react";
@@ -12,13 +11,13 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { geminiApiKeySchema } from "../types";
-
+import type { action } from "../route";
 export function GeminiApiKeyForm() {
-	const lastResult = useActionData<SubmissionResult>();
+	const actionData = useActionData<typeof action>();
 	const navigation = useNavigation();
 	const [form, { geminiApiKey }] = useForm({
 		id: "gemini-api-key-form",
-		lastResult,
+		lastResult: actionData?.lastResult,
 		constraint: getZodConstraint(geminiApiKeySchema),
 		shouldValidate: "onBlur",
 		shouldRevalidate: "onInput",


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
## リリースノート

### 変更内容

- Refactor: `GeminiApiKeyForm`コンポーネントの`lastResult`変数を`actionData?.lastResult`に置き換え、未使用のインポートを削除しました。
- Refactor: `useActionData`の型を"../route"からの`action`型に変更しました。

これらの変更により、コードの可読性と保守性が向上しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->