### PR TITLE
Refactor/translate route

### DIFF
--- a/web/app/routes/api.target-language.tsx
+++ b/web/app/routes/api.target-language.tsx
@@ -1,27 +1,22 @@
 import { json } from "@remix-run/node";
 import type { ActionFunction, LoaderFunction } from "@remix-run/node";
-import { commitSession, getSession } from "~/utils/session.server";
+import {
+	getTargetLanguage,
+	buildTargetLanguageCookie,
+} from "~/utils/target-language.server";
 
 export const loader: LoaderFunction = async ({ request }) => {
-	const session = await getSession(request.headers.get("Cookie"));
-	return json({ targetLanguage: session.get("targetLanguage") || "ja" });
+	const targetLanguage = await getTargetLanguage(request);
+	return json({ targetLanguage });
 };
 
 export const action: ActionFunction = async ({ request }) => {
-	const session = await getSession(request.headers.get("Cookie"));
 	const formData = await request.formData();
 	const targetLanguage = formData.get("targetLanguage");
 
 	if (typeof targetLanguage === "string") {
-		session.set("targetLanguage", targetLanguage);
-		return json(
-			{ success: true },
-			{
-				headers: {
-					"Set-Cookie": await commitSession(session),
-				},
-			},
-		);
+		const cookie = await buildTargetLanguageCookie(request, targetLanguage);
+		return json({ success: true }, { headers: { "Set-Cookie": cookie } });
 	}
 
 	return json({ success: false }, { status: 400 });

--- a/web/app/routes/reader.$encodedUrl/route.tsx
+++ b/web/app/routes/reader.$encodedUrl/route.tsx
@@ -13,10 +13,10 @@ import { TranslatedContent } from "./components/TranslatedContent";
 import type { TranslationData } from "./types";
 import { fetchLatestPageVersionWithTranslations } from "./utils";
 import { handleAddTranslationAction, handleVoteAction } from "./utils/actions";
+import { getTargetLanguage } from "~/utils/target-language.server";
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
-	const session = await getSession(request.headers.get("Cookie"));
-	const targetLanguage = session.get("targetLanguage") || "ja";
+	const targetLanguage = await getTargetLanguage(request);
 
 	const { encodedUrl } = params;
 	if (!encodedUrl) {
@@ -40,8 +40,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 export const action = async ({ request }: ActionFunctionArgs) => {
 	const safeUser = await authenticator.isAuthenticated(request);
 	const safeUserId = safeUser?.id;
-	const session = await getSession(request.headers.get("Cookie"));
-	const targetLanguage = session.get("targetLanguage") || "ja";
+	const targetLanguage = await getTargetLanguage(request);
 
 	if (!safeUserId) {
 		return json({ error: "User not authenticated" }, { status: 401 });

--- a/web/app/routes/translate/functions/mutations.server.ts
+++ b/web/app/routes/translate/functions/mutations.server.ts
@@ -1,0 +1,11 @@
+import { prisma } from "~/utils/prisma";
+
+export const updateGeminiApiKey = async (
+	userId: number,
+	geminiApiKey: string,
+) => {
+	await prisma.user.update({
+		where: { id: userId },
+		data: { geminiApiKey },
+	});
+};

--- a/web/app/routes/translate/functions/queries.server.ts
+++ b/web/app/routes/translate/functions/queries.server.ts
@@ -1,5 +1,5 @@
-import { prisma } from "~/utils/prisma";
 import { z } from "zod";
+import { prisma } from "~/utils/prisma";
 import { UserAITranslationInfoSchema } from "../types";
 
 export const getDbUser = async (userId: number) => {

--- a/web/app/routes/translate/functions/translate-job.server.ts
+++ b/web/app/routes/translate/functions/translate-job.server.ts
@@ -1,8 +1,8 @@
-import { fetchWithRetry } from "../../../feature/translate/utils/fetchWithRetry";
-import { extractArticle } from "../../../feature/translate/utils/extractArticle";
-import { addNumbersToContent } from "../../../feature/translate/utils/addNumbersToContent";
-import { extractNumberedElements } from "../../../feature/translate/utils/extractNumberedElements";
-import { translate } from "../../../feature/translate/libs/translation";
+import { translate } from "~/feature/translate/libs/translation";
+import { addNumbersToContent } from "~/feature/translate/utils/addNumbersToContent";
+import { extractArticle } from "~/feature/translate/utils/extractArticle";
+import { extractNumberedElements } from "~/feature/translate/utils/extractNumberedElements";
+import { fetchWithRetry } from "~/feature/translate/utils/fetchWithRetry";
 
 interface TranslateJobParams {
 	url: string;

--- a/web/app/routes/translate/functions/translate-job.server.ts
+++ b/web/app/routes/translate/functions/translate-job.server.ts
@@ -1,8 +1,8 @@
-import { fetchWithRetry } from "../../feature/translate/utils/fetchWithRetry";
-import { extractArticle } from "../../feature/translate/utils/extractArticle";
-import { addNumbersToContent } from "../../feature/translate/utils/addNumbersToContent";
-import { extractNumberedElements } from "../../feature/translate/utils/extractNumberedElements";
-import { translate } from "../../feature/translate/libs/translation";
+import { fetchWithRetry } from "../../../feature/translate/utils/fetchWithRetry";
+import { extractArticle } from "../../../feature/translate/utils/extractArticle";
+import { addNumbersToContent } from "../../../feature/translate/utils/addNumbersToContent";
+import { extractNumberedElements } from "../../../feature/translate/utils/extractNumberedElements";
+import { translate } from "../../../feature/translate/libs/translation";
 
 interface TranslateJobParams {
 	url: string;

--- a/web/app/routes/translate/route.tsx
+++ b/web/app/routes/translate/route.tsx
@@ -4,19 +4,19 @@ import { useRevalidator } from "@remix-run/react";
 import { useEffect } from "react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { Header } from "~/components/Header";
-import { authenticator } from "~/utils/auth.server";
-import { translateJob } from "./functions/translate-job.server";
 import { validateGeminiApiKey } from "~/feature/translate/utils/gemini";
+import { authenticator } from "~/utils/auth.server";
+import { getTargetLanguage } from "~/utils/target-language.server";
 import { GeminiApiKeyForm } from "./components/GeminiApiKeyForm";
 import { URLTranslationForm } from "./components/URLTranslationForm";
 import { UserAITranslationStatus } from "./components/UserAITranslationStatus";
-import { schema } from "./types";
+import { updateGeminiApiKey } from "./functions/mutations.server";
 import {
 	getDbUser,
 	listUserAiTransationInfo,
 } from "./functions/queries.server";
-import { updateGeminiApiKey } from "./functions/mutations.server";
-import { getTargetLanguage } from "~/utils/target-language.server";
+import { translateJob } from "./functions/translate-job.server";
+import { schema } from "./types";
 
 export async function loader({ request }: LoaderFunctionArgs) {
 	const safeUser = await authenticator.isAuthenticated(request, {
@@ -113,8 +113,8 @@ export default function TranslatePage() {
 			<Header safeUser={safeUser} />
 			<div className="container mx-auto max-w-2xl min-h-50 py-10">
 				<div className="pb-4">
-					{safeUser && hasGeminiApiKey && <URLTranslationForm />}
-					{safeUser && !hasGeminiApiKey && <GeminiApiKeyForm />}
+					{hasGeminiApiKey && <URLTranslationForm />}
+					{!hasGeminiApiKey && <GeminiApiKeyForm />}
 				</div>
 				<div>
 					<h2 className="text-2xl font-bold">Translation history</h2>

--- a/web/app/routes/translate/types.ts
+++ b/web/app/routes/translate/types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const geminiApiKeySchema = z.object({
+	intent: z.literal("saveGeminiApiKey"),
 	geminiApiKey: z.string().min(1, "API key is required"),
 });
 
@@ -12,6 +13,11 @@ export const urlTranslationSchema = z.object({
 		.url("有効なURLを入力してください"),
 	model: z.string().min(1, "モデルを選択してください"),
 });
+
+export const schema = z.discriminatedUnion("intent", [
+	geminiApiKeySchema,
+	urlTranslationSchema,
+]);
 
 export const PageVersionTranslationInfoSchema = z.object({
 	id: z.number(),

--- a/web/app/utils/session.server.ts
+++ b/web/app/utils/session.server.ts
@@ -1,6 +1,11 @@
 import { createCookieSessionStorage } from "@remix-run/node";
+import type { SafeUser } from "~/types";
 
-export const sessionStorage = createCookieSessionStorage({
+type Session = SafeUser & {
+	targetLanguage: string;
+};
+
+export const sessionStorage = createCookieSessionStorage<Session>({
 	cookie: {
 		name: "_session",
 		sameSite: "lax",

--- a/web/app/utils/target-language.server.ts
+++ b/web/app/utils/target-language.server.ts
@@ -1,0 +1,16 @@
+import { commitSession, getSession } from "~/utils/session.server";
+
+export const getTargetLanguage = async (request: Request) => {
+	const session = await getSession(request.headers.get("Cookie"));
+	const targetLanguage = String(session.get("targetLanguage")) || "ja";
+	return targetLanguage;
+};
+
+export const buildTargetLanguageCookie = async (
+	request: Request,
+	targetLanguage: string,
+) => {
+	const session = await getSession(request.headers.get("Cookie"));
+	session.set("targetLanguage", targetLanguage);
+	return await commitSession(session);
+};

--- a/web/app/utils/target-language.server.ts
+++ b/web/app/utils/target-language.server.ts
@@ -2,7 +2,7 @@ import { commitSession, getSession } from "~/utils/session.server";
 
 export const getTargetLanguage = async (request: Request) => {
 	const session = await getSession(request.headers.get("Cookie"));
-	const targetLanguage = String(session.get("targetLanguage")) || "ja";
+	const targetLanguage = session.get("targetLanguage") ?? "ja";
 	return targetLanguage;
 };
 


### PR DESCRIPTION
ちょっと整理してみました。お好みにもしあえばマージいただけると。

1. action での parseWithZod を z.discriminatedUnion を使って一回で済ませるように
2. route ディレクトリの中に functions ディレクトリを作成し、翻訳処理 translate-job.server.ts をここに移動。
3. prisma による DB 操作の処理を参照系を functions/queries.server.ts に、更新系を function/smutations.server.ts に分離
4. targetLanguage の取得・クッキー作成処理を utils/target-language.server.ts に分離
5. session を型安全に
6. organize imports 
