### PR TITLE
chore: Update PostgreSQL image version to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   db:
-    image: postgres:14
+    image: postgres:16
     restart: always
     environment:
       - POSTGRES_USER=postgres


### PR DESCRIPTION
本番環境に合わせてdockerで使っているdbのversionをpostgres14から16に上げました｡
既存の開発者が､最新のmainをfetchするとdataの互換性の問題でエラーが発生するため､dataを消すか､移行する必要があります｡

docker compose exec db pg_dumpall -U postgres > backup.sql
で既存dbをbackup後
docker compose down -v
でボリュームを削除し
docker compose up -d
docker compose exec -T db psql -U postgres < backup.sql

でdetaを移行できます!
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### リリースノート

#### Chore
- Docker Composeファイル内のPostgreSQLイメージバージョンを14から16に更新しました。

### 目的
この変更は、最新のPostgreSQLバージョンを使用することで、セキュリティとパフォーマンスの向上を図るためのものです。

### ユーザーストーリー
ユーザーとして、最新のデータベース機能と改善点を利用できるようにしたい。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->