### PR TITLE
Fix/release-note

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,7 +39,7 @@ version-resolver:
 template: |
   ## Changes
   $CHANGES
-  
+
 autolabeler:
   - label: feature
     branch:
@@ -59,3 +59,7 @@ autolabeler:
   - label: enhancement
     branch:
       - '/(enhancement|improve)[/-].+/'
+  - label: dependencies
+    branch:
+      - '/^dep(s)?[/-].+/'
+      - '/^dependency[/-].+/'

--- a/.github/workflows/create-release-note.yaml
+++ b/.github/workflows/create-release-note.yaml
@@ -3,7 +3,10 @@ name: Create Release Note
 on:
   pull_request:
     types:
-      - closed
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```markdown
## リリースノート

### Chore
- `.github/release-drafter.yml`の`version-resolver`テンプレートから不要な空白行を削除しました。
- `autolabeler`に新しいラベル「dependencies」を追加しました。このラベルは、ブランチ名が`/^dep(s)?[/-].+/`または`/^dependency[/-].+/`に一致する場合に適用されます。

### New Feature
- GitHub Actionsの設定ファイル（`.github/workflows/create-release-note.yaml`）において、`pull_request`イベントに対してトリガーされるアクションの種類として`opened`、`reopened`、`synchronize`、および`ready_for_review`を追加しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->