### PR TITLE
feat: Add auto-labeling for issues based on their titles

### DIFF
--- a/.github/workflows/auto-label-issue.yml
+++ b/.github/workflows/auto-label-issue.yml
@@ -17,18 +17,14 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          if [[ $ISSUE_TITLE =~ ^(feat:|feature:) ]]; then
-            LABEL="feature"
-          elif [[ $ISSUE_TITLE =~ ^(fix:|bug:) ]]; then
-            LABEL="bug"
-          elif [[ $ISSUE_TITLE =~ ^(docs:|documentation:) ]]; then
-            LABEL="documentation"
-          elif [[ $ISSUE_TITLE =~ ^refactor: ]]; then
-            LABEL="refactor"
-          elif [[ $ISSUE_TITLE =~ ^chore: ]]; then
-            LABEL="chore"
-          else
-            LABEL="task"
-          fi
+          case "$ISSUE_TITLE" in
+            feat:*|feature:*) LABEL="feature" ;;
+            fix:*|bug:*) LABEL="bug" ;;
+            docs:*|documentation:*) LABEL="documentation" ;;
+            refactor:*) LABEL="refactor" ;;
+            chore:*) LABEL="chore" ;;
+            *) LABEL="task" ;;
+          esac
           
           gh issue edit $ISSUE_NUMBER --add-label "$LABEL"
+

--- a/.github/workflows/auto-label-issue.yml
+++ b/.github/workflows/auto-label-issue.yml
@@ -1,0 +1,34 @@
+name: Auto Label Issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  auto_label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Label issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          if [[ $ISSUE_TITLE =~ ^feat:|^feature: ]]; then
+            LABEL="feature"
+          elif [[ $ISSUE_TITLE =~ ^fix:|^bug: ]]; then
+            LABEL="bug"
+          elif [[ $ISSUE_TITLE =~ ^docs:|^documentation: ]]; then
+            LABEL="documentation"
+          elif [[ $ISSUE_TITLE =~ ^refactor: ]]; then
+            LABEL="refactor"
+          elif [[ $ISSUE_TITLE =~ ^chore: ]]; then
+            LABEL="chore"
+          else
+            LABEL="task"
+          fi
+          
+          gh issue edit $ISSUE_NUMBER --add-label "$LABEL"

--- a/.github/workflows/auto-label-issue.yml
+++ b/.github/workflows/auto-label-issue.yml
@@ -17,11 +17,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          if [[ $ISSUE_TITLE =~ ^feat:|^feature: ]]; then
+          if [[ $ISSUE_TITLE =~ ^(feat:|feature:) ]]; then
             LABEL="feature"
-          elif [[ $ISSUE_TITLE =~ ^fix:|^bug: ]]; then
+          elif [[ $ISSUE_TITLE =~ ^(fix:|bug:) ]]; then
             LABEL="bug"
-          elif [[ $ISSUE_TITLE =~ ^docs:|^documentation: ]]; then
+          elif [[ $ISSUE_TITLE =~ ^(docs:|documentation:) ]]; then
             LABEL="documentation"
           elif [[ $ISSUE_TITLE =~ ^refactor: ]]; then
             LABEL="refactor"


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### リリースノート

#### New Feature
- GitHub Actionsを使用して、問題のタイトルに基づいて自動的にラベルを付ける「Auto Label Issue」ワークフローが追加されました。特定のキーワード（例：`feat:`, `fix:`, `docs:`など）に基づいてラベルが決定され、該当するラベル（例：`feature`, `bug`, `documentation`など）が問題に追加されます。デフォルトでは「task」ラベルが適用されます。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->