### PR TITLE
chore: Update create-branch-on-issue-assign.yml to include task type

### DIFF
--- a/.github/workflows/create-branch-on-issue-assign.yml
+++ b/.github/workflows/create-branch-on-issue-assign.yml
@@ -18,6 +18,7 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ASSIGNEE: ${{ github.event.assignee.login }}
         run: |
+          TYPE="task"
           LABELS=$(gh issue view $ISSUE_NUMBER --json labels -q '.labels[].name')
           
           for LABEL in $LABELS; do


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### リリースノート

#### New Feature
- GitHub Actionsのワークフローファイル `create-branch-on-issue-assign.yml` に新しい変数 `TYPE` が `"task"` として追加されました。これにより、課題が割り当てられた際に特定のタイプのブランチを自動的に作成する機能が強化されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->