### PR TITLE
feat: Update Translation component styling for better readability

### DIFF
--- a/web/app/routes/reader.$encodedUrl/components/Translation.tsx
+++ b/web/app/routes/reader.$encodedUrl/components/Translation.tsx
@@ -57,7 +57,7 @@ export function Translation({
 
 	return (
 		<div className="group relative">
-			<div className="w-full notranslate mt-2 pt-2 border-t border-gray-200">
+			<div className="w-full notranslate mt-2 py-2 border-b border-gray-200">
 				{sanitizedAndParsedText}
 				<ToggleButton
 					isExpanded={isExpanded}


### PR DESCRIPTION
Closes #123
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### リリースノート

- Style: `Translation`コンポーネントのスタイリングを変更しました。具体的には、内部の `<div>` 要素のクラス名を変更し、上部のパディング (`pt-2`) を全体のパディング (`py-2`) に変更し、ボーダーを上部から下部に移動しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->