### PR TITLE
改行問題に対応するためJSDOMから変更

### DIFF
--- a/web/app/feature/translate/utils/generateGeminiMessage.ts
+++ b/web/app/feature/translate/utils/generateGeminiMessage.ts
@@ -42,6 +42,7 @@ export function generateSystemMessage(
   - Ensure that each "text" field contains at least one character.
   - Maintain the original array structure and order, with the title translation added as the first item.
   - Output ONLY the translated JSON array. No additional text or explanations.
+  - Preserve and output newline characters (\n) as they are. It is important to maintain line breaks within the text.
   
   Input text:
   ${source_text}
@@ -54,7 +55,7 @@ export function generateSystemMessage(
     },
     {
       "number": 2,
-      "text": "Translated text for item 2"
+      "text": "Translated text \n for item 2"
     },
     ...
   ]`;


### PR DESCRIPTION
Closes #144
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### リリースノート

#### New Feature
- `extractNumberedElements`関数がHTML解析に`htmlparser2`を使用するように変更され、`data-number`属性を持つ要素のテキスト内容を収集する機能が追加されました。

#### Refactor
- `generateSystemMessage`関数の出力フォーマットに関する指示が追加され、テキスト内の改行文字（\n）をそのまま保持して出力するように修正されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->