### PR TITLE
Add showOriginal and showTranslation props with FloatingControls for translation components

### DIFF
--- a/web/app/routes/$userName+/page+/$slug+/components/ContentWithTranslations.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/ContentWithTranslations.tsx
@@ -21,6 +21,8 @@ interface ContentWithTranslationsProps {
 	hasGeminiApiKey: boolean;
 	userAITranslationInfo: UserAITranslationInfo | null;
 	targetLanguage: string;
+	showOriginal: boolean;
+	showTranslation: boolean;
 }
 
 export function ContentWithTranslations({
@@ -30,6 +32,8 @@ export function ContentWithTranslations({
 	hasGeminiApiKey,
 	userAITranslationInfo,
 	targetLanguage,
+	showOriginal = true,
+	showTranslation = true,
 }: ContentWithTranslationsProps) {
 	const isHydrated = useHydrated();
 	const [selectedSourceTextId, setSelectedSourceTextId] = useState<
@@ -62,6 +66,8 @@ export function ContentWithTranslations({
 						sourceLanguage={pageWithTranslations.page.sourceLanguage}
 						targetLanguage={targetLanguage}
 						onOpenAddAndVoteTranslations={handleOpenAddAndVoteTranslations}
+						showOriginal={true}
+						showTranslation={true}
 					/>
 				)}
 			</h1>
@@ -115,6 +121,8 @@ export function ContentWithTranslations({
 						targetLanguage={targetLanguage}
 						currentUserName={currentUserName}
 						onOpenAddAndVoteTranslations={handleOpenAddAndVoteTranslations}
+						showOriginal={showOriginal}
+						showTranslation={showTranslation}
 					/>
 					{selectedSourceTextWithTranslations && (
 						<AddAndVoteTranslations

--- a/web/app/routes/$userName+/page+/$slug+/components/FloatingControls.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/FloatingControls.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState, useCallback } from "react";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/utils/cn";
+import { LikeButton } from "~/routes/resources+/like-button";
+import { ShareDialog } from "./ShareDialog";
+import { Languages, FileText } from "lucide-react";
+
+interface FloatingControlsProps {
+  showOriginal: boolean;
+  showTranslation: boolean;
+  onToggleOriginal: () => void;
+  onToggleTranslation: () => void;
+  liked: boolean;
+  likeCount: number;
+  slug: string;
+  shareUrl: string;
+  shareTitle: string;
+}
+
+export function FloatingControls({
+  showOriginal,
+  showTranslation,
+  onToggleOriginal,
+  onToggleTranslation,
+  liked,
+  likeCount,
+  slug,
+  shareUrl,
+  shareTitle,
+}: FloatingControlsProps) {
+  const [isVisible, setIsVisible] = useState(true);
+  const [lastScrollY, setLastScrollY] = useState(0);
+
+  const handleScroll = useCallback(() => {
+    const currentScrollY = window.scrollY;
+    const scrollDelta = currentScrollY - lastScrollY;
+    
+    // 100px以上の下スクロールの時だけ非表示に
+    if (scrollDelta > 100) {
+      setIsVisible(false);
+    } else if (scrollDelta < 0 || currentScrollY < 100) {
+      setIsVisible(true);
+    }
+
+    setLastScrollY(currentScrollY);
+  }, [lastScrollY]);
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll]);
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-4 right-4 flex gap-2 transition-all duration-300 transform",
+        isVisible ? "translate-y-0 opacity-100" : "translate-y-20 opacity-0"
+      )}
+    >
+      <div className="bg-background/80 backdrop-blur-sm rounded-lg shadow-lg p-2 flex gap-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onToggleOriginal}
+          title={showOriginal ? "Hide original text" : "Show original text"}
+        >
+          <FileText className={cn("h-4 w-4", !showOriginal && "opacity-50")} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onToggleTranslation}
+          title={showTranslation ? "Hide translation" : "Show translation"}
+        >
+          <Languages className={cn("h-4 w-4", !showTranslation && "opacity-50")} />
+        </Button>
+        <div className="w-px bg-border" />
+        <LikeButton liked={liked} likeCount={likeCount} slug={slug} />
+        <ShareDialog url={shareUrl} title={shareTitle} />
+      </div>
+    </div>
+  );
+}

--- a/web/app/routes/$userName+/page+/$slug+/components/FloatingControls.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/FloatingControls.tsx
@@ -1,85 +1,87 @@
-import { useEffect, useState, useCallback } from "react";
+import { FileText, Languages } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "~/components/ui/button";
-import { cn } from "~/utils/cn";
 import { LikeButton } from "~/routes/resources+/like-button";
+import { cn } from "~/utils/cn";
 import { ShareDialog } from "./ShareDialog";
-import { Languages, FileText } from "lucide-react";
 
 interface FloatingControlsProps {
-  showOriginal: boolean;
-  showTranslation: boolean;
-  onToggleOriginal: () => void;
-  onToggleTranslation: () => void;
-  liked: boolean;
-  likeCount: number;
-  slug: string;
-  shareUrl: string;
-  shareTitle: string;
+	showOriginal: boolean;
+	showTranslation: boolean;
+	onToggleOriginal: () => void;
+	onToggleTranslation: () => void;
+	liked: boolean;
+	likeCount: number;
+	slug: string;
+	shareUrl: string;
+	shareTitle: string;
 }
 
 export function FloatingControls({
-  showOriginal,
-  showTranslation,
-  onToggleOriginal,
-  onToggleTranslation,
-  liked,
-  likeCount,
-  slug,
-  shareUrl,
-  shareTitle,
+	showOriginal,
+	showTranslation,
+	onToggleOriginal,
+	onToggleTranslation,
+	liked,
+	likeCount,
+	slug,
+	shareUrl,
+	shareTitle,
 }: FloatingControlsProps) {
-  const [isVisible, setIsVisible] = useState(true);
-  const [lastScrollY, setLastScrollY] = useState(0);
+	const [isVisible, setIsVisible] = useState(true);
+	const [lastScrollY, setLastScrollY] = useState(0);
 
-  const handleScroll = useCallback(() => {
-    const currentScrollY = window.scrollY;
-    const scrollDelta = currentScrollY - lastScrollY;
-    
-    // 100px以上の下スクロールの時だけ非表示に
-    if (scrollDelta > 100) {
-      setIsVisible(false);
-    } else if (scrollDelta < 0 || currentScrollY < 100) {
-      setIsVisible(true);
-    }
+	const handleScroll = useCallback(() => {
+		const currentScrollY = window.scrollY;
+		const scrollDelta = currentScrollY - lastScrollY;
 
-    setLastScrollY(currentScrollY);
-  }, [lastScrollY]);
+		// 100px以上の下スクロールの時だけ非表示に
+		if (scrollDelta > 100) {
+			setIsVisible(false);
+		} else if (scrollDelta < 0 || currentScrollY < 100) {
+			setIsVisible(true);
+		}
 
-  useEffect(() => {
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, [handleScroll]);
+		setLastScrollY(currentScrollY);
+	}, [lastScrollY]);
 
-  return (
-    <div
-      className={cn(
-        "fixed bottom-4 right-4 flex gap-2 transition-all duration-300 transform",
-        isVisible ? "translate-y-0 opacity-100" : "translate-y-20 opacity-0"
-      )}
-    >
-      <div className="bg-background/80 backdrop-blur-sm rounded-lg shadow-lg p-2 flex gap-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onToggleOriginal}
-          title={showOriginal ? "Hide original text" : "Show original text"}
-        >
-          <FileText className={cn("h-4 w-4", !showOriginal && "opacity-50")} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onToggleTranslation}
-          title={showTranslation ? "Hide translation" : "Show translation"}
-        >
-          <Languages className={cn("h-4 w-4", !showTranslation && "opacity-50")} />
-        </Button>
-        <div className="w-px bg-border" />
-        <LikeButton liked={liked} likeCount={likeCount} slug={slug} />
-        <ShareDialog url={shareUrl} title={shareTitle} />
-      </div>
-    </div>
-  );
+	useEffect(() => {
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => {
+			window.removeEventListener("scroll", handleScroll);
+		};
+	}, [handleScroll]);
+
+	return (
+		<div
+			className={cn(
+				"fixed bottom-4 right-4 flex gap-2 transition-all duration-300 transform",
+				isVisible ? "translate-y-0 opacity-100" : "translate-y-20 opacity-0",
+			)}
+		>
+			<div className="bg-background/80 backdrop-blur-sm rounded-lg shadow-lg p-2 flex gap-2">
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onToggleOriginal}
+					title={showOriginal ? "Hide original text" : "Show original text"}
+				>
+					<FileText className={cn("h-4 w-4", !showOriginal && "opacity-50")} />
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onToggleTranslation}
+					title={showTranslation ? "Hide translation" : "Show translation"}
+				>
+					<Languages
+						className={cn("h-4 w-4", !showTranslation && "opacity-50")}
+					/>
+				</Button>
+				<div className="w-px bg-border" />
+				<LikeButton liked={liked} likeCount={likeCount} slug={slug} />
+				<ShareDialog url={shareUrl} title={shareTitle} />
+			</div>
+		</div>
+	);
 }

--- a/web/app/routes/$userName+/page+/$slug+/components/ParsedContent.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/ParsedContent.tsx
@@ -13,6 +13,8 @@ interface ParsedContentProps {
 	targetLanguage: string;
 	currentUserName: string | undefined;
 	onOpenAddAndVoteTranslations: (sourceTextId: number) => void;
+	showOriginal: boolean;
+	showTranslation: boolean;
 }
 
 export const MemoizedParsedContent = memo(ParsedContent);
@@ -23,6 +25,8 @@ export function ParsedContent({
 	targetLanguage,
 	currentUserName,
 	onOpenAddAndVoteTranslations,
+	showOriginal = true,
+	showTranslation = true,
 }: ParsedContentProps) {
 	const sanitizedContent = DOMPurify.sanitize(
 		pageWithTranslations.page.content,
@@ -61,6 +65,8 @@ export function ParsedContent({
 							sourceLanguage={sourceLanguage}
 							targetLanguage={targetLanguage}
 							onOpenAddAndVoteTranslations={onOpenAddAndVoteTranslations}
+							showOriginal={showOriginal}
+							showTranslation={showTranslation}
 						/>
 					</DynamicTag>
 				);

--- a/web/app/routes/$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
@@ -9,6 +9,8 @@ export function SourceTextAndTranslationSection({
 	targetLanguage,
 	sourceTextClassName,
 	onOpenAddAndVoteTranslations,
+	showOriginal = true,
+	showTranslation = true,
 }: {
 	sourceTextWithTranslations: SourceTextWithTranslations;
 	elements: string | React.ReactNode | React.ReactNode[];
@@ -17,27 +19,32 @@ export function SourceTextAndTranslationSection({
 	targetLanguage: string;
 	sourceTextClassName?: string;
 	onOpenAddAndVoteTranslations: (sourceTextId: number) => void;
+	showOriginal: boolean;
+	showTranslation: boolean;
 }) {
 	return (
 		<>
-			<span
-				className={`inline-block ${
-					sourceTextWithTranslations.translationsWithVotes.length === 0
-						? "text-gray-700 dark:text-gray-200"
-						: "text-gray-300 dark:text-gray-600"
-				} ${sourceTextClassName}`}
-			>
-				{isPublished === false && <Lock className="h-6 w-6 mr-1 inline" />}
-				{elements}
-			</span>
-			{sourceLanguage === targetLanguage ||
-			sourceTextWithTranslations.translationsWithVotes.length === 0 ? null : (
-				<TranslationSection
-					key={`translation-${sourceTextWithTranslations.sourceText.id}`}
-					sourceTextWithTranslations={sourceTextWithTranslations}
-					onOpenAddAndVoteTranslations={onOpenAddAndVoteTranslations}
-				/>
+			{showOriginal && (
+				<span
+					className={`inline-block ${
+						sourceTextWithTranslations.translationsWithVotes.length === 0
+							? "text-gray-700 dark:text-gray-200"
+							: "text-gray-300 dark:text-gray-600"
+					} ${sourceTextClassName}`}
+				>
+					{isPublished === false && <Lock className="h-6 w-6 mr-1 inline" />}
+					{elements}
+				</span>
 			)}
+			{showTranslation &&
+				sourceLanguage !== targetLanguage &&
+				sourceTextWithTranslations.translationsWithVotes.length > 0 && (
+					<TranslationSection
+						key={`translation-${sourceTextWithTranslations.sourceText.id}`}
+						sourceTextWithTranslations={sourceTextWithTranslations}
+						onOpenAddAndVoteTranslations={onOpenAddAndVoteTranslations}
+					/>
+				)}
 		</>
 	);
 }

--- a/web/app/routes/$userName+/page+/$slug+/index.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/index.tsx
@@ -4,14 +4,14 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { useActionData } from "@remix-run/react";
 import type { MetaFunction } from "@remix-run/react";
 import { useLoaderData } from "@remix-run/react";
+import { useState } from "react";
 import { getTranslateUserQueue } from "~/features/translate/translate-user-queue";
 import i18nServer from "~/i18n.server";
 import { getNonSanitizedUserbyUserName } from "~/routes/functions/queries.server";
-import { LikeButton } from "~/routes/resources+/like-button";
 import { authenticator } from "~/utils/auth.server";
 import { stripHtmlTags } from "../../utils/stripHtmlTags";
 import { ContentWithTranslations } from "./components/ContentWithTranslations";
-import { ShareDialog } from "./components/ShareDialog";
+import { FloatingControls } from "./components/FloatingControls";
 import { createUserAITranslationInfo } from "./functions/mutations.server";
 import {
 	fetchIsLikedByUser,
@@ -201,10 +201,12 @@ export default function Page() {
 		lastResult: actionData?.lastResult,
 	});
 
+	const [showOriginal, setShowOriginal] = useState(true);
+	const [showTranslation, setShowTranslation] = useState(true);
 	const shareUrl = typeof window !== "undefined" ? window.location.href : "";
 
 	return (
-		<div className=" w-full max-w-3xl  mx-auto">
+		<div className="w-full max-w-3xl mx-auto">
 			<article className="w-full prose dark:prose-invert prose-a:underline prose-a:decoration-dotted sm:prose lg:prose-lg mx-auto mb-20">
 				<ContentWithTranslations
 					pageWithTranslations={pageWithTranslations}
@@ -213,6 +215,8 @@ export default function Page() {
 					hasGeminiApiKey={hasGeminiApiKey}
 					userAITranslationInfo={userAITranslationInfo}
 					targetLanguage={targetLanguage}
+					showOriginal={showOriginal}
+					showTranslation={showTranslation}
 				/>
 				<div className="flex flex-wrap gap-2">
 					{pageWithTranslations.tagPages.map((tagPage) => (
@@ -224,18 +228,18 @@ export default function Page() {
 						</div>
 					))}
 				</div>
-				<div className="flex justify-between items-center mt-8 mx-4">
-					<LikeButton
-						liked={isLikedByUser}
-						likeCount={likeCount}
-						slug={pageWithTranslations.page.slug}
-					/>
-					<ShareDialog
-						url={shareUrl}
-						title={sourceTitleWithBestTranslationTitle}
-					/>
-				</div>
 			</article>
+			<FloatingControls
+				showOriginal={showOriginal}
+				showTranslation={showTranslation}
+				onToggleOriginal={() => setShowOriginal(!showOriginal)}
+				onToggleTranslation={() => setShowTranslation(!showTranslation)}
+				liked={isLikedByUser}
+				likeCount={likeCount}
+				slug={pageWithTranslations.page.slug}
+				shareUrl={shareUrl}
+				shareTitle={sourceTitleWithBestTranslationTitle}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
This pull request introduces `showOriginal` and `showTranslation` props to various translation components, allowing users to toggle the visibility of original text and translations. A new `FloatingControls` component has been implemented to manage these toggles, enhancing the user interface and experience. The default values for these props are set to true, ensuring that both original text and translations are displayed by default.