### PR TITLE
Refactor button styles to use ghost variant and update layout

### DIFF
--- a/web/app/routes/$userName+/page+/$slug+/components/FloatingControls.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/FloatingControls.tsx
@@ -59,18 +59,18 @@ export function FloatingControls({
 			)}
 		>
 			<Button
-				variant="secondary"
+				variant="ghost"
 				size="icon"
-				className="h-12 w-12 rounded-full shadow-lg"
+				className="h-12 w-12 rounded-full border bg-background"
 				onClick={onToggleOriginal}
 				title={showOriginal ? "Hide original text" : "Show original text"}
 			>
 				<FileText className={cn("h-5 w-5", !showOriginal && "opacity-50")} />
 			</Button>
 			<Button
-				variant="secondary"
+				variant="ghost"
 				size="icon"
-				className="h-12 w-12 rounded-full shadow-lg"
+				className="h-12 w-12 rounded-full border bg-background"
 				onClick={onToggleTranslation}
 				title={showTranslation ? "Hide translation" : "Show translation"}
 			>

--- a/web/app/routes/$userName+/page+/$slug+/components/ShareDialog.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/ShareDialog.tsx
@@ -29,9 +29,9 @@ export function ShareDialog({ url, title }: ShareDialogProps) {
 		<Dialog open={isOpen} onOpenChange={setIsOpen} modal={false}>
 			<DialogTrigger asChild>
 				<Button
-					variant="secondary"
+					variant="ghost"
 					size="icon"
-					className="h-12 w-12 rounded-full shadow-lg"
+					className="h-12 w-12 rounded-full border bg-background"
 				>
 					<Share className="h-5 w-5" />
 				</Button>

--- a/web/app/routes/home/_home.tsx
+++ b/web/app/routes/home/_home.tsx
@@ -107,6 +107,7 @@ export default function Home() {
 									liked={page.likePages.length > 0}
 									likeCount={page._count.likePages}
 									slug={page.slug}
+									showCount
 								/>
 							</div>
 						</CardContent>

--- a/web/app/routes/resources+/like-button.tsx
+++ b/web/app/routes/resources+/like-button.tsx
@@ -39,9 +39,9 @@ export function LikeButton({
 				<Button
 					type="submit"
 					aria-label="Like"
-					variant="secondary"
+					variant="ghost"
 					size="icon"
-					className={`h-12 w-12 rounded-full shadow-lg ${className}`}
+					className={`h-12 w-12 rounded-full border bg-background ${className}`}
 					disabled={fetcher.state === "submitting"}
 				>
 					<Heart


### PR DESCRIPTION
This pull request updates the button styles across multiple components to use the 'ghost' variant instead of 'secondary', enhancing the visual consistency. Additionally, it modifies the button classes to include a border and background for improved layout and appearance. The changes also introduce a new prop, `showCount`, in the Home component to manage display logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `showCount` prop to the `LikeButton` component on the Home page to display the number of likes.

- **Style**
	- Updated the visual styling of buttons in the `FloatingControls`, `ShareDialog`, and `LikeButton` components for a more modern appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->