### PR TITLE
Fix image URL retrieval logic and update Twitter card type

### DIFF
--- a/web/app/routes/$userName+/index.tsx
+++ b/web/app/routes/$userName+/index.tsx
@@ -52,6 +52,7 @@ import {
 	fetchPageById,
 	fetchSanitizedUserWithPages,
 } from "./functions/queries.server";
+
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
 	if (!data) {
 		return [{ title: "Profile" }];

--- a/web/app/routes/$userName+/page+/$slug+/index.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/index.tsx
@@ -35,11 +35,12 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 		0,
 		200,
 	);
-	const firstImageMatch = pageWithTranslations.page.content.match(/<img[^>]+src="([^">]+)"/);
-	const imageUrl = firstImageMatch 
-		? firstImageMatch[1] 
+	const firstImageMatch = pageWithTranslations.page.content.match(
+		/<img[^>]+src="([^">]+)"/,
+	);
+	const imageUrl = firstImageMatch
+		? firstImageMatch[1]
 		: pageWithTranslations.user.icon;
-
 
 	return [
 		{ title: sourceTitleWithBestTranslationTitle },

--- a/web/app/routes/$userName+/page+/$slug+/index.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/index.tsx
@@ -35,7 +35,11 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 		0,
 		200,
 	);
-	const imageUrl = pageWithTranslations.user.icon;
+	const firstImageMatch = pageWithTranslations.page.content.match(/<img[^>]+src="([^">]+)"/);
+	const imageUrl = firstImageMatch 
+		? firstImageMatch[1] 
+		: pageWithTranslations.user.icon;
+
 
 	return [
 		{ title: sourceTitleWithBestTranslationTitle },
@@ -44,7 +48,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 		{ property: "og:title", content: sourceTitleWithBestTranslationTitle },
 		{ property: "og:description", content: description },
 		{ property: "og:image", content: imageUrl },
-		{ name: "twitter:card", content: "summary" },
+		{ name: "twitter:card", content: "summary_large_image" },
 		{ name: "twitter:title", content: sourceTitleWithBestTranslationTitle },
 		{ name: "twitter:description", content: description },
 		{ name: "twitter:image", content: imageUrl },


### PR DESCRIPTION
This pull request modifies the logic for retrieving the image URL to ensure that the first image found in the page content is used, falling back to the user's icon if no image is present. Additionally, the Twitter card type has been updated from "summary" to "summary_large_image" to better accommodate larger images.