### PR TITLE
Fix translation display logic in SourceTextAndTranslationSection

### DIFF
--- a/web/app/routes/$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
@@ -26,11 +26,10 @@ export function SourceTextAndTranslationSection({
 		<>
 			{showOriginal && (
 				<span
-					className={`inline-block ${
-						sourceTextWithTranslations.translationsWithVotes.length === 0
+					className={`inline-block ${sourceTextWithTranslations.translationsWithVotes.length === 0 || !showTranslation
 							? "text-gray-700 dark:text-gray-200"
 							: "text-gray-300 dark:text-gray-600"
-					} ${sourceTextClassName}`}
+						} ${sourceTextClassName}`}
 				>
 					{isPublished === false && <Lock className="h-6 w-6 mr-1 inline" />}
 					{elements}

--- a/web/app/routes/$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
+++ b/web/app/routes/$userName+/page+/$slug+/components/sourceTextAndTranslationSection/SourceTextAndTranslationSection.tsx
@@ -26,10 +26,12 @@ export function SourceTextAndTranslationSection({
 		<>
 			{showOriginal && (
 				<span
-					className={`inline-block ${sourceTextWithTranslations.translationsWithVotes.length === 0 || !showTranslation
+					className={`inline-block ${
+						sourceTextWithTranslations.translationsWithVotes.length === 0 ||
+						!showTranslation
 							? "text-gray-700 dark:text-gray-200"
 							: "text-gray-300 dark:text-gray-600"
-						} ${sourceTextClassName}`}
+					} ${sourceTextClassName}`}
 				>
 					{isPublished === false && <Lock className="h-6 w-6 mr-1 inline" />}
 					{elements}


### PR DESCRIPTION
This PR updates the logic for displaying translations in the `SourceTextAndTranslationSection` component. It ensures that the original text is displayed correctly based on the state of the `showTranslation` flag, improving the user experience when viewing source text and translations.