### PR TITLE
新しいページリストコンポーネントを追加し、人気ページリストを新しいページリストに置き換え

### DIFF
--- a/next/src/app/[locale]/(common-layout)/page.tsx
+++ b/next/src/app/[locale]/(common-layout)/page.tsx
@@ -67,9 +67,8 @@ const DynamicControl = dynamic(
 );
 import { StartButton } from "@/app/[locale]/_components/start-button";
 
-const PopularPageListByTag = dynamic(
-	() =>
-		import("@/app/[locale]/_components/page/popular-page-list-by-tag/server"),
+const NewPageListByTag = dynamic(
+	() => import("@/app/[locale]/_components/page/new-page-list-by-tag/server"),
 	{
 		loading: () => <Skeleton className="h-[400px] w-full mb-10" />,
 	},
@@ -110,25 +109,9 @@ export default async function HomePage({
 			)}
 			<DynamicControl />
 			<>
-				<PopularPageListByTag locale={locale} tagName="AI" />
-				<PopularPageListByTag locale={locale} tagName="Programming" />
-				<PopularPageListByTag locale={locale} tagName="Plurality" />
-				<SortTabs defaultSort={sort} />
-				{sort === "popular" ? (
-					<>
-						<PopularPageList
-							locale={locale}
-							searchParams={searchParams}
-							showPagination
-						/>
-					</>
-				) : (
-					<NewPageList
-						locale={locale}
-						searchParams={searchParams}
-						showPagination
-					/>
-				)}
+				<NewPageListByTag locale={locale} tagName="AI" />
+				<NewPageListByTag locale={locale} tagName="Programming" />
+				<NewPageListByTag locale={locale} tagName="Plurality" />
 			</>
 		</div>
 	);

--- a/next/src/app/[locale]/_components/page/new-page-list-by-tag/_db/queries.server.ts
+++ b/next/src/app/[locale]/_components/page/new-page-list-by-tag/_db/queries.server.ts
@@ -1,0 +1,75 @@
+import {
+	normalizePageSegments,
+	selectPagesWithDetails,
+} from "@/app/[locale]/_db/page-queries.server";
+import { toSegmentBundles } from "@/app/[locale]/_lib/to-segment-bundles";
+import type { PageSummary } from "@/app/[locale]/types";
+import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+export interface FetchPaginatedNewestPagesByTagParams {
+	tagName: string;
+	page?: number;
+	pageSize?: number;
+	locale?: string;
+	currentUserId?: string;
+}
+
+/**
+ * Fetch paginated public page summaries filtered by given tag name and ordered by newest (createdAt desc).
+ */
+export async function fetchPaginatedPublicNewestPageSummariesByTag({
+	tagName,
+	page = 1,
+	pageSize = 5,
+	locale = "en",
+	currentUserId,
+}: FetchPaginatedNewestPagesByTagParams): Promise<{
+	pageSummaries: PageSummary[];
+	totalPages: number;
+}> {
+	const skip = (page - 1) * pageSize;
+
+	const baseWhere: Prisma.PageWhereInput = {
+		status: "PUBLIC",
+		tagPages: {
+			some: {
+				tag: {
+					name: tagName,
+				},
+			},
+		},
+	};
+
+	const orderBy: Prisma.PageOrderByWithRelationInput[] = [
+		{ createdAt: "desc" },
+	];
+
+	const select = selectPagesWithDetails(true, locale, currentUserId);
+
+	const [rawPages, total] = await Promise.all([
+		prisma.page.findMany({
+			where: baseWhere,
+			orderBy,
+			skip,
+			take: pageSize,
+			select,
+		}),
+		prisma.page.count({ where: baseWhere }),
+	]);
+
+	const pages = rawPages.map((p) => ({
+		...p,
+		createdAt: p.createdAt.toISOString(),
+		segmentBundles: toSegmentBundles(
+			"page",
+			p.id,
+			normalizePageSegments(p.pageSegments),
+		),
+	}));
+
+	return {
+		pageSummaries: pages,
+		totalPages: Math.ceil(total / pageSize),
+	};
+}

--- a/next/src/app/[locale]/_components/page/new-page-list-by-tag/server.tsx
+++ b/next/src/app/[locale]/_components/page/new-page-list-by-tag/server.tsx
@@ -1,0 +1,72 @@
+"use server";
+
+import { PageListContainer } from "@/app/[locale]/_components/page/page-list-container/server";
+import { PageList } from "@/app/[locale]/_components/page/page-list.server";
+import { PaginationBar } from "@/app/[locale]/_components/pagination-bar";
+import { getCurrentUser } from "@/auth";
+import { SparklesIcon } from "lucide-react";
+import { createLoader, parseAsInteger } from "nuqs/server";
+import type { SearchParams } from "nuqs/server";
+import { fetchPaginatedPublicNewestPageSummariesByTag } from "./_db/queries.server";
+
+const searchParamsSchema = {
+	page: parseAsInteger.withDefault(1),
+};
+
+const loadSearchParams = createLoader(searchParamsSchema);
+
+interface NewPageListByTagProps {
+	locale: string;
+	tagName: string;
+	/**
+	 * Forward request searchParams for pagination when needed.
+	 * Optional because we may render without pagination.
+	 */
+	searchParams?: Promise<SearchParams>;
+	showPagination?: boolean;
+}
+
+export default async function NewPageListByTag({
+	locale,
+	tagName,
+	searchParams,
+	showPagination = false,
+}: NewPageListByTagProps) {
+	const { page } = searchParams
+		? await loadSearchParams(searchParams)
+		: { page: 1 };
+	const currentUser = await getCurrentUser();
+	const currentUserHandle = currentUser?.handle;
+
+	const { pageSummaries, totalPages } =
+		await fetchPaginatedPublicNewestPageSummariesByTag({
+			tagName,
+			page,
+			pageSize: 5,
+			locale,
+			currentUserId: currentUser?.id,
+		});
+
+	if (pageSummaries.length === 0) {
+		return null;
+	}
+
+	return (
+		<PageListContainer title={`${tagName}`} icon={SparklesIcon}>
+			{pageSummaries.map((pageSummary, index) => (
+				<PageList
+					key={pageSummary.id}
+					pageSummary={pageSummary}
+					index={index}
+					locale={locale}
+					currentUserHandle={currentUserHandle}
+				/>
+			))}
+			{showPagination && totalPages > 1 && (
+				<div className="mt-8 flex justify-center">
+					<PaginationBar totalPages={totalPages} currentPage={page} />
+				</div>
+			)}
+		</PageListContainer>
+	);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 「AI」「プログラミング」「Plurality」タグごとに最新の公開ページリストを表示する機能を追加しました。

- **改善**
  - ページリストの表示が「人気順」から「新着順」に変更されました。
  - ソートタブや人気/新着の切り替え機能が削除され、よりシンプルな表示になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->