### PR TITLE
グローバルCSSの色指定をデフォルトに変更し、ダークモードの入力レイの色に!importantを追加

### DIFF
--- a/next/src/app/globals.css
+++ b/next/src/app/globals.css
@@ -110,11 +110,11 @@
 		transparent 0.5deg,
 		transparent 3deg
 	);
-	color: rgba(0, 0, 0, 0.4); /* ライト */
+	color: rgba(0, 0, 0, 0.4); /* デフォルト */
 }
 
 .dark .input-rays {
-	color: rgba(255, 255, 255, 0.8); /* ダーク */
+	color: rgba(255, 255, 255, 0.8) !important; /* ダーク */
 }
 
 /* ----- 右 (出力) ----- */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - `.input-rays`のコメント表記を「ライト」から「デフォルト」に変更しました。
  - ダークモード時の`.input-rays`に`!important`を追加し、コメントも更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->