### PR TITLE
GoogleFormとHeroSectionのボタンスタイルを更新し、StartButtonに内側ハイライトと外周グローを追加

### DIFF
--- a/src/app/[locale]/(common-layout)/auth/login/_components/google-form.tsx
+++ b/src/app/[locale]/(common-layout)/auth/login/_components/google-form.tsx
@@ -14,7 +14,7 @@ export function GoogleForm({ redirectTo }: { redirectTo: string }) {
 		<Form action={formAction} className="w-full ">
 			<input type="hidden" name="redirectTo" value={redirectTo} />
 			<Button
-				variant="outline"
+				variant="default"
 				disabled={isPending}
 				className="w-full rounded-full h-12 text-md"
 			>

--- a/src/app/[locale]/_components/hero-section/server.tsx
+++ b/src/app/[locale]/_components/hero-section/server.tsx
@@ -60,7 +60,7 @@ export default async function HeroSection({ locale }: { locale: string }) {
 				</span>
 				<div className="mb-12 flex justify-center mt-10">
 					<StartButton
-						text="Join Now"
+						text="Start Now"
 						icon={
 							<Image
 								src="/favicon.svg"
@@ -70,7 +70,7 @@ export default async function HeroSection({ locale }: { locale: string }) {
 								className="relative z-10 invert dark:invert-0"
 							/>
 						}
-						className="w-60 h-12 text-xl rounded-full transition-all duration-300 hover:scale-105"
+						className="w-60 h-16 text-xl transition-all duration-300 hover:scale-105"
 					/>
 				</div>
 				<div className="relative  my-10 flex justify-center">

--- a/src/app/[locale]/_components/start-button.tsx
+++ b/src/app/[locale]/_components/start-button.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/routing";
+import { cn } from "@/lib/utils";
+
 interface StartButtonProps {
 	className?: string;
 	text?: string;
@@ -18,11 +20,23 @@ export function StartButton({
 		>
 			<Button
 				variant="default"
-				className={`${className} rounded-full`}
 				size="lg"
+				className={cn(
+					"relative  rounded-full",
+
+					/* ── 内側ハイライト ::before ── */
+					"before:absolute before:inset-0 before:rounded-full ",
+					"before:bg-[linear-gradient(145deg,rgba(255,255,255,0.35)_0%,rgba(255,255,255,0.05)_40%,transparent_80%)]",
+
+					/* ── 外周グロー ::after（ダーク限定で発光） ── */
+					"after:absolute after:inset-0 after:rounded-full",
+					"after:opacity-100 after:shadow-[0_0_20px_4px_rgba(255,255,255,0.12)]",
+
+					className,
+				)}
 			>
 				<div className="flex items-center gap-2">
-					{icon && icon}
+					{icon}
 					<span className="sr-only">login and start</span>
 					{text}
 				</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - Googleログインボタンのデザインを「アウトライン」から「デフォルト」に変更しました。
  - 「Start Now」ボタンのラベルを「Join Now」から「Start Now」に変更し、高さを拡大、角丸を調整しました。
  - 「Start Now」ボタンに新しいグラデーションとシャドウ効果を追加し、見た目を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->