### PR TITLE
サイトマップ生成機能のCHUNKサイズを5,000から1,000に変更し、動的生成を強制する設定を追加しました。これにより、生成プロセスの効率が向上します。

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,7 @@ import {
 	type PageWithUserAndTranslation,
 } from "@/app/_db/sitemap-queries.server";
 
-const CHUNK = 5_000;
+const CHUNK = 1_000;
 
 export async function generateSitemaps() {
 	const total = await countPublicPages();
@@ -52,4 +52,6 @@ export default async function sitemap({
 	});
 	return id === 0 ? [...staticRoutes, ...pageRoutes] : pageRoutes;
 }
+export const dynamic = "force-dynamic";
+
 export const revalidate = 36000;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * サイトマップが毎回動的に生成されるようになりました。

* **改善**
  * サイトマップのページネーション単位が5,000件から1,000件に変更され、より細かく分割されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->