### PR TITLE
biome.jsonのスキーマを2.2.2に更新し、ファイルの除外パターンを修正しました。また、bun.lockとpackage.jsonで@biomejs/biomeのバージョンを2.2.2に更新し、tipitaka.tsでの配列操作を改善しました。

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,300 @@
+
+  You are an expert in TypeScript, Node.js, Next.js App Router, React, Shadcn UI, Radix UI and Tailwind.
+  
+  # Evame プロジェクトアーキテクチャガイド
+
+このドキュメントでは、Evameプロジェクトのアーキテクチャ、構造、および開発のためのガイドラインを提供します。
+
+## 目次
+
+- [プロジェクト概要](#プロジェクト概要)
+- [技術スタック](#技術スタック)
+- [ディレクトリ構造](#ディレクトリ構造)
+- [主要コンポーネント](#主要コンポーネント)
+- [データフロー](#データフロー)
+- [コンポーネント開発ガイドライン](#コンポーネント開発ガイドライン)
+- [データ取得とミューテーション](#データ取得とミューテーション)
+- [国際化対応](#国際化対応)
+
+## プロジェクト概要
+
+Evame はNext.js（App Router）を使用したWebアプリケーションで、モダンなUI/UX設計を採用しています。プロジェクトはモノレポ構造を採用しており、メインのアプリケーションコードは `next` ディレクトリに集約されています。
+
+## 技術スタック
+
+- **フレームワーク**: Next.js 15 (App Router)
+- **言語**: TypeScript
+- **UI コンポーネント**: 
+  - Shadcn UI (Radix UI ベース)
+  - React 19
+- **スタイリング**: Tailwind CSS
+- **データベース**: Prisma ORM を使用した PostgreSQL
+- **認証**: better auth
+- **国際化**: next-intl
+- **状態管理**: React Server Components + nuqs (URL検索パラメータ管理)
+- **エディタ**: TipTap
+
+## ディレクトリ構造
+
+プロジェクトは次のようなディレクトリ構造になっています：
+
+```
+/
+├── next/                         # メインアプリケーションコード
+│   ├── src/                      # ソースコード
+│   │   ├── app/                  # Next.js App Router
+│   │   │   ├── [locale]/         # 国際化対応ルート
+│   │   │   │   ├── (common-layout)/ # 共通レイアウト
+│   │   │   │   ├── (edit-layout)/   # 編集用レイアウト
+│   │   │   │   ├── _components/     # ルート固有のコンポーネント
+│   │   │   │   └── _lib/            # ルート固有のユーティリティ
+│   │   │   ├── api/              # API ルート
+│   │   │   └── _db/              # データベース関連コード
+│   │   ├── components/           # 共有コンポーネント
+│   │   │   └── ui/               # UI コンポーネント (Shadcn UI)
+│   │   ├── features/             # 機能ごとのコード
+│   │   ├── lib/                  # ユーティリティ関数
+│   │   ├── types/                # 型定義
+│   │   └── i18n/                 # 国際化設定
+│   ├── prisma/                   # Prisma スキーマとマイグレーション
+│   └── public/                   # 静的ファイル
+└── components/                   # クロームエクステンション用コンポーネント（空）
+```
+
+## 主要コンポーネント
+
+### UI コンポーネント (Shadcn UI)
+
+`next/src/components/ui` ディレクトリには、Shadcn UI フレームワークに基づく再利用可能なUIコンポーネントがあります：
+
+- ボタン、入力フィールド、チェックボックスなどの基本要素
+- モーダル、ポップオーバー、ドロップダウンメニューなどの複合コンポーネント
+- テーブル、ページネーション、カルーセルなどの高度なコンポーネント
+
+これらのコンポーネントは Radix UI をベースにしており、アクセシビリティに優れ、カスタマイズ可能です。
+
+### ルートと国際化
+
+アプリケーションは国際化に対応しており、`[locale]` パラメータを使用してルーティングされています。`next-intl` を使用して翻訳を管理しています。
+
+- ルートパスには `[locale]` セグメントが含まれ、それぞれの言語に対応するサブルートがあります
+- 翻訳メッセージは `next/messages` ディレクトリにあります
+
+### データベース
+
+データベースは Prisma ORM を使用して管理されています：
+
+- スキーマ定義: `next/prisma/schema.prisma`
+- マイグレーション: `next/prisma/migrations/`
+- シードスクリプト: `next/prisma/seed.ts`
+
+### 認証
+
+認証は better auth を使用して実装されています：
+
+- 認証設定: `next/src/auth.ts`
+
+## データフロー
+
+アプリケーションは主にReact Server Componentsを使用し、必要に合わせてClient Componentsを活用します：
+
+1. データ取得は主にサーバーコンポーネントで行われます
+2. ユーザーインタラクションが必要な場合は `"use client"` ディレクティブを使用してクライアントコンポーネントを作成します
+3. フォーム送信やデータ変更には Server Actions を使用します
+4. URL検索パラメータの状態管理には `nuqs` を使用します
+
+## コンポーネント開発ガイドライン
+
+新しいコンポーネントを作成する際は、以下のガイドラインに従ってください：
+
+### コンポーネントの配置
+
+1. **共有UI部品**: `next/src/components/ui/` - 基本的なUIコンポーネント
+2. **機能固有部品**: `next/src/features/{feature-name}/components/` - 特定の機能に関連するコンポーネント
+3. **ページ固有部品**: `next/src/app/[locale]/{route}/_components/` - 特定のページ/ルートに関連するコンポーネント
+
+### コンポーネントの構造
+
+```typescript
+// component-name.tsx
+"use client"; // クライアントコンポーネントの場合のみ
+
+import { type FC } from "react";
+import { cn } from "@/lib/utils";
+
+interface ComponentNameProps {
+  // プロパティの型定義
+}
+
+export const ComponentName: FC<ComponentNameProps> = ({
+  // プロパティの分割代入
+}) => {
+  // フック、状態、副作用
+
+  // JSXの返却
+  return (
+    <div className={cn("...", className)}>
+      {/* コンポーネントの内容 */}
+    </div>
+  );
+};
+```
+
+### 命名規則
+
+- **ディレクトリ**: ケバブケース (`auth-wizard/`)
+- **コンポーネントファイル**: ケバブケース (`auth-wizard.tsx`)
+- **ユーティリティ/フックファイル**: ケバブケース (`use-auth-state.ts`)
+
+## データ取得とミューテーション
+
+データの取得と変更操作はプロジェクト内で一貫したパターンに従っています。
+
+### データ取得パターン
+
+1. **フォルダ構造**:
+   - コンポーネントがデータを必要とする場合、そのコンポーネントと同じディレクトリに `_db` ディレクトリを作成します
+   - 例: `components/project/new-project-list/_db/`
+
+2. **クエリファイル**:
+   - データ取得関数は `_db/queries.server.ts` ファイルに配置します
+   - 命名規則: `fetch{データ名}` (例: `fetchNewProjectsWithPagination`)
+   - これらの関数は常に非同期関数として実装します
+
+3. **サーバーコンポーネント**:
+   - データを取得するサーバーコンポーネントは通常 `server.tsx` ファイルに実装します
+   - データ取得とレンダリングを結合したコンポーネントとして機能します
+
+```typescript
+// コンポーネント例: new-project-list/server.tsx
+import { fetchNewProjectsWithPagination } from "./_db/queries.server";
+
+export default async function NewProjectList({ page, query }: Props) {
+  const { projectsWithRelations } = await fetchNewProjectsWithPagination(page, 10, query);
+  
+  return (
+    <ComponentToRenderData data={projectsWithRelations} />
+  );
+}
+```
+
+```typescript
+// クエリ例: _db/queries.server.ts
+import { prisma } from "@/lib/prisma";
+
+export async function fetchNewProjectsWithPagination(
+  page = 1,
+  pageSize = 10,
+  searchTerm = "",
+) {
+  // Prismaを使用したデータ取得ロジック
+  const data = await prisma.someModel.findMany({ /* ... */ });
+  return { data };
+}
+```
+
+### ミューテーションパターン
+
+1. **フォルダ構造**:
+   - ミューテーション（データ変更）が必要なコンポーネントは次のファイル構成を持ちます：
+     - `action.ts`: Server Action定義
+     - `client.tsx`: クライアントコンポーネント
+     - `db/mutations.server.ts`: データベース操作
+
+2. **Server Action**:
+   - Server Actionは `action.ts` ファイルで定義し、先頭に `"use server"` ディレクティブを記述します
+   - 入力バリデーションにはZodを使用します
+   - アクション関数は命名規則: `{操作}Action` (例: `togglePageLikeAction`)
+
+3. **ミューテーション関数**:
+   - 実際のデータベース操作は `db/mutations.server.ts` に実装します
+   - 命名規則: 操作を表す動詞から始める (例: `togglePageLike`, `createNotification`)
+
+4. **クライアントコンポーネント**:
+   - `"use client"` ディレクティブを持つコンポーネントは通常 `client.tsx` に実装します
+   - Server Actionを呼び出すフォームやボタンを含みます
+   - Optimistic UIの実装には `useOptimistic` を使用します
+
+```typescript
+// action.ts
+"use server";
+
+import { z } from "zod";
+import { togglePageLike } from "./db/mutations.server";
+
+const schema = z.object({ slug: z.string() });
+
+export async function togglePageLikeAction(previousState, formData: FormData) {
+  const validation = schema.safeParse({ slug: formData.get("slug") });
+  if (!validation.success) {
+    return { success: false, zodErrors: validation.error.flatten().fieldErrors };
+  }
+  
+  // データベース操作
+  const result = await togglePageLike(validation.data.slug, { /* ... */ });
+  
+  return { success: true, data: result };
+}
+```
+
+```typescript
+// db/mutations.server.ts
+import { prisma } from "@/lib/prisma";
+
+export async function togglePageLike(slug: string, identifier) {
+  // Prismaを使用したデータベース操作
+  // ...
+  return { liked, likeCount };
+}
+```
+
+```typescript
+// client.tsx
+"use client";
+
+import { useActionState, useOptimistic } from "react";
+import { togglePageLikeAction } from "./action";
+
+export function PageLikeButton({ liked, likeCount, slug }: Props) {
+  const [state, formAction] = useActionState(togglePageLikeAction, { success: false });
+  const [optimisticLiked, updateOptimisticLiked] = useOptimistic(liked, (_, newValue) => newValue);
+  
+  // コンポーネントのレンダリング
+}
+```
+
+### テスト
+
+- データ取得関数とミューテーション関数のテストは、それぞれ `queries.server.test.ts` と `mutations.server.test.ts` に記述します
+- モックを使用してPrismaの動作をシミュレートします
+
+## 国際化対応
+
+1. メッセージを追加する場合は `next/messages/{locale}` ディレクトリ内の適切なファイルに追加します
+2. コンポーネント内でメッセージを使用する場合：
+
+```typescript
+// サーバーコンポーネントの場合
+import { getTranslations } from "next-intl/server";
+
+export async function MyComponent() {
+  const t = await getTranslations("namespace");
+  return <div>{t("key")}</div>;
+}
+
+// クライアントコンポーネントの場合
+"use client";
+import { useTranslations } from "next-intl";
+
+export function MyComponent() {
+  const t = useTranslations("namespace");
+  return <div>{t("key")}</div>;
+}
+```
+
+
+このガイドに従うことで、一貫性のあるコンポーネントを開発し、プロジェクト全体の整合性を維持することができます。 
+
+
+  Follow Next.js docs for Data Fetching, Rendering, and Routing.
+  

--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,14 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
 	"files": {
 		"includes": [
 			"**",
 			"!bun.lockb",
-			"!build/**",
-			"!.vscode/**",
-			"!.next/**",
-			"!node_modules/**"
+			"!build",
+			"!.vscode",
+			"!.next",
+			"!node_modules",
+			"!**/*.css"
 		]
 	},
 	"assist": {
@@ -22,9 +23,7 @@
 		"rules": {
 			"recommended": true,
 			"correctness": {
-				"noUnusedImports": "error"
-			},
-			"nursery": {
+				"noUnusedImports": "error",
 				"useUniqueElementIds": "off"
 			}
 		}

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "@radix-ui/react-scroll-area": "1.2.9",
         "@radix-ui/react-select": "2.2.5",
         "@radix-ui/react-separator": "1.1.7",
-        "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-switch": "1.2.5",
         "@radix-ui/react-tabs": "1.1.12",
         "@radix-ui/react-toggle": "1.1.9",
@@ -109,7 +109,7 @@
         "zod": "4.0.14",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.1.3",
+        "@biomejs/biome": "2.2.2",
         "@next/bundle-analyzer": "15.4.5",
         "@playwright/test": "1.54.1",
         "@tailwindcss/postcss": "4.1.11",
@@ -314,23 +314,23 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.18", "", {}, "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.1.3", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.1.3", "@biomejs/cli-darwin-x64": "2.1.3", "@biomejs/cli-linux-arm64": "2.1.3", "@biomejs/cli-linux-arm64-musl": "2.1.3", "@biomejs/cli-linux-x64": "2.1.3", "@biomejs/cli-linux-x64-musl": "2.1.3", "@biomejs/cli-win32-arm64": "2.1.3", "@biomejs/cli-win32-x64": "2.1.3" }, "bin": { "biome": "bin/biome" } }, "sha512-KE/tegvJIxTkl7gJbGWSgun7G6X/n2M6C35COT6ctYrAy7SiPyNvi6JtoQERVK/VRbttZfgGq96j2bFmhmnH4w=="],
+    "@biomejs/biome": ["@biomejs/biome@2.2.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.2.2", "@biomejs/cli-darwin-x64": "2.2.2", "@biomejs/cli-linux-arm64": "2.2.2", "@biomejs/cli-linux-arm64-musl": "2.2.2", "@biomejs/cli-linux-x64": "2.2.2", "@biomejs/cli-linux-x64-musl": "2.2.2", "@biomejs/cli-win32-arm64": "2.2.2", "@biomejs/cli-win32-x64": "2.2.2" }, "bin": { "biome": "bin/biome" } }, "sha512-j1omAiQWCkhuLgwpMKisNKnsM6W8Xtt1l0WZmqY/dFj8QPNkIoTvk4tSsi40FaAAkBE1PU0AFG2RWFBWenAn+w=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LFLkSWRoSGS1wVUD/BE6Nlt2dSn0ulH3XImzg2O/36BoToJHKXjSxzPEMAqT9QvwVtk7/9AQhZpTneERU9qaXA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6ePfbCeCPryWu0CXlzsWNZgVz/kBEvHiPyNpmViSt6A2eoDf4kXs3YnwQPzGjy8oBgQulrHcLnJL0nkCh80mlQ=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.1.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Q/4OTw8P9No9QeowyxswcWdm0n2MsdCwWcc5NcKQQvzwPjwuPdf8dpPPf4r+x0RWKBtl1FLiAUtJvBlri6DnYw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tn4JmVO+rXsbRslml7FvKaNrlgUeJot++FkvYIhl1OkslVCofAtS35MPlBMhXgKWF9RNr9cwHanrPTUUXcYGag=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-2hS6LgylRqMFmAZCOFwYrf77QMdUwJp49oe8PX/O8+P2yKZMSpyQTf3Eo5ewnsMFUEmYbPOskafdV1ds1MZMJA=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-KXouFSBnoxAWZYDQrnNRzZBbt5s9UJkIm40hdvSL9mBxSSoxRFQJbtg1hP3aa8A2SnXyQHxQfpiVeJlczZt76w=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-/MhYg+Bd6renn6i1ylGFL5snYUn/Ct7zoGVKhxnro3bwekiZYE8Kl39BSb0MeuqM+72sThkQv4TnNubU9njQRw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-NxlSCBhLvQtWGagEztfAZ4WcE1AkMTntZV65ZvR+J9jp06+EtOYEBPQndA70ZGhHbEDG57bR6uNvqkd1WrEYVA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-KaLAxnROouzIWtl6a0Y88r/4hW5oDUJTIqQorOTVQITaKQsKjZX4XCUmHIhdEk8zMnaiLZzRTAwk1yIAl+mIew=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.1.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-V9CUZCtWH4u0YwyCYbQ3W5F4ZGPWp2C2TYcsiWFNNyRfmOW1j/TY/jAurl33SaRjgZPO5UUhGyr9m6BN9t84NQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-dxy599q6lgp8ANPpR8sDMscwdp9oOumEsVXuVCVT9N2vAho8uYXlCz53JhxX6LtJOXaE73qzgkGQ7QqvFlMC0g=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.0.2", "", {}, "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA=="],
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 		"zod": "4.0.14"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.1.3",
+		"@biomejs/biome": "2.2.2",
 		"@next/bundle-analyzer": "15.4.5",
 		"@playwright/test": "1.54.1",
 		"@tailwindcss/postcss": "4.1.11",

--- a/scripts/tipitaka.ts
+++ b/scripts/tipitaka.ts
@@ -71,7 +71,7 @@ function parseMarkdown(src: string) {
 			.replace(splitTiRe, (m) => m.replace(/\s+“$/, "\n\n“"));
 
 		// 5) 改行が入ったら分割して配列へ
-		x.split("\n").forEach((seg) => cleanedBodyLines.push(seg));
+		cleanedBodyLines.push(...x.split("\n"));
 	}
 
 	const bodyText = cleanedBodyLines.join("\n").replace(/\n{3,}/g, "\n\n");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- ドキュメント
  - Evame のアーキテクチャ／開発ガイドを新規追加。Next.js 15 モノレポ構成、ディレクトリ指針、RSC/Server Actions、i18n、データ取得・更新パターン、テスト方針、コンポーネント規約を網羅。

- チョア
  - 静的解析ツールを最新スキーマへ更新し、除外ルールとリンタ設定を調整。未使用インポート検出を強化。
  - 開発依存関係を更新（安定性と整合性の向上）。

- リファクタ
  - 実装を軽微に簡素化（動作変更なし）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->