### PR TITLE
ページデータ取得ロジックの修正: `pageWithTitleAndTags`が存在しない場合の処理を簡素化し、タイトルの取得をオプショナルに変更しました。これにより、エラー処理の整合性が向上しました。

### DIFF
--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/page.tsx
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/page.tsx
@@ -25,10 +25,7 @@ const getPageData = cache(async (handle: string, pageSlug: string) => {
 			getAllTagsWithCount(),
 			getUserTargetLocales(currentUser.id),
 		]);
-	if (!pageWithTitleAndTags) {
-		return notFound();
-	}
-	const title = pageWithTitleAndTags.content.segments[0].text;
+	const title = pageWithTitleAndTags?.content.segments[0].text;
 	return {
 		currentUser,
 		pageWithTitleAndTags,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ページデータが存在しない場合でも編集画面が開くようにし、不要な404発生を防止。
  * タイトルが取得できない際に「Edit Page」を自動適用し、メタデータの欠落を回避。
  * 欠損データ時の初期タイトルおよび本文レンダリングを安全化し、空コンテンツでもエラーなく表示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->