### PR TITLE
Tipitaka スクリプトの改善: Markdown ファイルの取り込み処理を強化し、ページとセグメントの同期を行うユーティリティ関数 `syncSegments` を追加しました。また、ページ作成や更新のロジックを整理し、キュー処理を実装しました。これにより、Markdown の階層構造を効率的に管理できるようになりました。テストも追加し、機能の信頼性を向上させました。

### DIFF
--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_db/mutations.server.ts
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_db/mutations.server.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from "@prisma/client";
 import { ContentKind } from "@prisma/client";
 import type { SegmentDraft } from "@/app/[locale]/_lib/remark-hash-and-segments";
+import { syncSegments } from "@/app/[locale]/_lib/sync-segments";
 import { prisma } from "@/lib/prisma";
 
 export async function upsertPageAndSegments(p: {
@@ -48,74 +49,7 @@ export async function upsertPageAndSegments(p: {
 		}
 	});
 
-	await syncPageSegments(page.id, p.segments);
-}
-
-/** 1ページ分のセグメントを同期 */
-async function syncPageSegments(pageId: number, drafts: SegmentDraft[]) {
-	// ページに関連するContentを取得
-	const page = await prisma.page.findUnique({
-		where: { id: pageId },
-		select: { id: true },
-	});
-
-	if (!page?.id) {
-		throw new Error(`Page ${pageId} does not have a content`);
-	}
-
-	const existing = await prisma.segment.findMany({
-		where: { contentId: page.id },
-		select: { textAndOccurrenceHash: true },
-	});
-	const stale = new Set(existing.map((e) => e.textAndOccurrenceHash));
-
-	await prisma.$transaction(async (tx) => {
-		// A. 並び避難（既存あれば）
-		if (existing.length) {
-			await tx.segment.updateMany({
-				where: { contentId: page.id },
-				data: { number: { increment: 1_000_000 } },
-			});
-		}
-
-		// B. UPSERT を **適度なバッチ & 逐次 await** で安定
-		const CHUNK = 200;
-		for (let i = 0; i < drafts.length; i += CHUNK) {
-			const chunk = drafts.slice(i, i + CHUNK);
-			await Promise.all(
-				chunk.map((d) =>
-					tx.segment.upsert({
-						where: {
-							contentId_textAndOccurrenceHash: {
-								contentId: page.id,
-								textAndOccurrenceHash: d.hash,
-							},
-						},
-						update: { text: d.text, number: d.number },
-						create: {
-							contentId: page.id,
-							text: d.text,
-							number: d.number,
-							textAndOccurrenceHash: d.hash,
-						},
-					}),
-				),
-			);
-			for (const d of chunk) {
-				stale.delete(d.hash);
-			}
-		}
-
-		// C. 余った行を一括削除
-		if (stale.size) {
-			await tx.segment.deleteMany({
-				where: {
-					contentId: page.id,
-					textAndOccurrenceHash: { in: [...stale] },
-				},
-			});
-		}
-	});
+	await syncSegments(prisma, page.id, p.segments);
 }
 
 export async function upsertTags(tags: string[], pageId: number) {

--- a/src/app/[locale]/_lib/sync-segments.test.ts
+++ b/src/app/[locale]/_lib/sync-segments.test.ts
@@ -1,0 +1,84 @@
+import { ContentKind, type Segment } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { generateHashForText } from "@/app/[locale]/_lib/generate-hash-for-text";
+import type { SegmentDraft } from "@/app/[locale]/_lib/remark-hash-and-segments";
+import { syncSegments } from "@/app/[locale]/_lib/sync-segments";
+import { prisma } from "@/lib/prisma";
+
+describe("syncSegments", () => {
+	let contentId: number | null = null;
+
+	beforeEach(async () => {
+		const content = await prisma.content.create({
+			data: { kind: ContentKind.PAGE },
+		});
+		contentId = content.id;
+	});
+
+	afterEach(async () => {
+		if (contentId === null) return;
+		await prisma.segment.deleteMany({ where: { contentId } });
+		await prisma.content.delete({ where: { id: contentId } });
+		contentId = null;
+	});
+
+	test("upserts and reorders segments while dropping stale entries", async () => {
+		if (contentId === null) throw new Error("contentId not initialized");
+
+		const initialDrafts: SegmentDraft[] = [
+			{ hash: generateHashForText("Title", 0), text: "Title", number: 0 },
+			{ hash: generateHashForText("Line 1", 1), text: "Line 1", number: 1 },
+			{ hash: generateHashForText("Line 2", 1), text: "Line 2", number: 2 },
+		];
+
+		await syncSegments(prisma, contentId, initialDrafts);
+
+		let stored = await prisma.segment.findMany({
+			where: { contentId },
+			orderBy: { number: "asc" },
+		});
+
+		expect(stored.map((s: Segment) => s.text)).toEqual([
+			"Title",
+			"Line 1",
+			"Line 2",
+		]);
+
+		const updatedDrafts: SegmentDraft[] = [
+			{ hash: generateHashForText("Title", 0), text: "Title", number: 0 },
+			{ hash: generateHashForText("Line 2", 1), text: "Line 2", number: 1 },
+			{ hash: generateHashForText("Line 3", 1), text: "Line 3", number: 2 },
+		];
+
+		await syncSegments(prisma, contentId, updatedDrafts);
+
+		stored = await prisma.segment.findMany({
+			where: { contentId },
+			orderBy: { number: "asc" },
+		});
+
+		expect(stored.map((s: Segment) => s.text)).toEqual([
+			"Title",
+			"Line 2",
+			"Line 3",
+		]);
+		expect(stored.find((s) => s.text === "Line 2")?.number).toBe(1);
+		expect(stored.some((s) => s.text === "Line 1")).toBe(false);
+	});
+
+	test("deletes all segments when drafts are empty", async () => {
+		if (contentId === null) throw new Error("contentId not initialized");
+
+		const drafts: SegmentDraft[] = [
+			{ hash: generateHashForText("Title", 0), text: "Title", number: 0 },
+			{ hash: generateHashForText("Line 1", 1), text: "Line 1", number: 1 },
+		];
+
+		await syncSegments(prisma, contentId, drafts);
+
+		await syncSegments(prisma, contentId, []);
+
+		const stored = await prisma.segment.findMany({ where: { contentId } });
+		expect(stored).toHaveLength(0);
+	});
+});

--- a/src/app/[locale]/_lib/sync-segments.ts
+++ b/src/app/[locale]/_lib/sync-segments.ts
@@ -1,0 +1,68 @@
+import type { PrismaClient } from "@prisma/client";
+import type { SegmentDraft } from "@/app/[locale]/_lib/remark-hash-and-segments";
+
+/**
+ * SegmentDraft[] を segments テーブルに同期する共通ヘルパー。
+ * textAndOccurrenceHash をキーに既存レコードを保持しつつ更新する。
+ */
+export async function syncSegments(
+	prisma: PrismaClient,
+	contentId: number,
+	drafts: SegmentDraft[],
+) {
+	if (!drafts.length) {
+		await prisma.segment.deleteMany({ where: { contentId } });
+		return;
+	}
+
+	const existing = await prisma.segment.findMany({
+		where: { contentId },
+		select: { textAndOccurrenceHash: true },
+	});
+	const stale = new Set(existing.map((e) => e.textAndOccurrenceHash));
+
+	await prisma.$transaction(async (tx) => {
+		if (existing.length) {
+			await tx.segment.updateMany({
+				where: { contentId },
+				data: { number: { increment: 1_000_000 } },
+			});
+		}
+
+		const CHUNK = 200;
+		for (let i = 0; i < drafts.length; i += CHUNK) {
+			const chunk = drafts.slice(i, i + CHUNK);
+			await Promise.all(
+				chunk.map((d) =>
+					tx.segment.upsert({
+						where: {
+							contentId_textAndOccurrenceHash: {
+								contentId,
+								textAndOccurrenceHash: d.hash,
+							},
+						},
+						update: { text: d.text, number: d.number },
+						create: {
+							contentId,
+							text: d.text,
+							number: d.number,
+							textAndOccurrenceHash: d.hash,
+						},
+					}),
+				),
+			);
+			for (const d of chunk) {
+				stale.delete(d.hash);
+			}
+		}
+
+		if (stale.size) {
+			await tx.segment.deleteMany({
+				where: {
+					contentId,
+					textAndOccurrenceHash: { in: [...stale] },
+				},
+			});
+		}
+	});
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - Tipitaka ページのURLが安定化（決定的スラッグ生成）し、ページ作成・更新がより一貫した挙動に。
- リファクタ
  - Tipitaka インポート処理をキュー駆動型に刷新し、ページとコンテンツの同期フローを整理。
  - コメント投稿とページ編集でのセグメント同期を共通ユーティリティに統合。
- テスト
  - セグメント同期のテストを追加し、挿入・並び替え・削除の動作を検証。
- 雑務
  - ルートディレクトリ定数の導入とエラーハンドリングの明確化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->