### PR TITLE
chore: exclude jsdom from server-side bundle in Next.js configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -87,6 +87,9 @@ const config: NextConfig = {
 			},
 		];
 	},
+	// Turbopack/Webpackのサーバーサイドバンドルからjsdomを除外
+	// isomorphic-dompurifyはjsdomに依存しているが、クライアントコンポーネントでのみ使用されるため
+	serverExternalPackages: ["jsdom", "isomorphic-dompurify", "parse5"],
 };
 
 export default analyzeBundles(


### PR DESCRIPTION
- Added `serverExternalPackages` to exclude `jsdom` and `isomorphic-dompurify` from the server-side bundle, as they are only used in client components.