### PR TITLE
chore: update build configuration and refactor HTML parsing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -87,9 +87,6 @@ const config: NextConfig = {
 			},
 		];
 	},
-	// Turbopack/Webpackのサーバーサイドバンドルからjsdomを除外
-	// isomorphic-dompurifyはjsdomに依存しているが、クライアントコンポーネントでのみ使用されるため
-	serverExternalPackages: ["jsdom", "isomorphic-dompurify", "parse5"],
 };
 
 export default analyzeBundles(

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "next dev",
-		"build": "next build",
+		"build": "next build --webpack",
 		"start": "next start",
 		"lint": "eslint .",
 		"test": "vitest",
@@ -90,7 +90,6 @@
 		"lucide-react": "0.552.0",
 		"nanoid": "5.1.6",
 		"next": "16.0.1",
-		"node-html-parser": "7.0.1",
 		"next-intl": "4.4.0",
 		"next-themes": "0.4.6",
 		"nextjs-toploader": "3.9.17",

--- a/src/app/[locale]/_lib/get-locale-from-html.ts
+++ b/src/app/[locale]/_lib/get-locale-from-html.ts
@@ -1,20 +1,20 @@
 import { loadModule } from "cld3-asm";
-import { parse } from "node-html-parser";
+import { JSDOM } from "jsdom";
 
 export async function getLocaleFromHtml(
 	htmlContent: string,
 	userLocale: string,
 ): Promise<string> {
-	const doc = parse(htmlContent);
+	const doc = new JSDOM(htmlContent);
 
-	// Remove code and anchor elements
-	doc.querySelectorAll("code, a").forEach((el) => {
+	for (const el of doc.window.document.querySelectorAll("code, a")) {
 		el.remove();
-	});
+	}
 
-	const contents = doc
-		.querySelectorAll("p,h1,h2,h3,h4,h5,h6,li,td,th")
-		.map((el) => el.text?.trim() ?? "")
+	const contents = [
+		...doc.window.document.querySelectorAll("p,h1,h2,h3,h4,h5,h6,li,td,th"),
+	]
+		.map((el) => el.textContent?.trim() ?? "")
 		.filter(Boolean)
 		.join("\n");
 


### PR DESCRIPTION
- Changed the build script in `package.json` to use Webpack.
- Removed `node-html-parser` dependency and replaced it with `jsdom` for HTML parsing in `get-locale-from-html.ts`.
- Updated the logic for removing elements and extracting text content from the HTML document.