### PR TITLE
fix: update directUrl in Prisma schema datasource configuration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  directUrl = env("DATABASE_URL_UNPOOLED")
+  directUrl = env("POSTGRES_PRISMA_URL")
 }
 
 model User {


### PR DESCRIPTION
- Changed `directUrl` from `DATABASE_URL_UNPOOLED` to `POSTGRES_PRISMA_URL` in the Prisma schema to align with the new environment variable naming.