### PR TITLE
refactor: update revalidation logic and Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  directUrl = env("POSTGRES_PRISMA_URL")
+  directUrl = env("DATABASE_URL_UNPOOLED")
 }
 
 model User {

--- a/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/page.tsx
+++ b/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/page.tsx
@@ -20,7 +20,8 @@ type Params = Promise<{ locale: string; handle: string; pageSlug: string }>;
 // Force static rendering for this route (no dynamic APIs allowed)
 export const dynamic = "force-static";
 // Optionally enable ISR; adjust as needed
-export const revalidate = 3600;
+// Revalidate once per month (30 days = 2,592,000 seconds)
+export const revalidate = 2592000;
 
 export async function generateMetadata({
 	params,

--- a/src/app/[locale]/_components/wrap-segments/translation-section/translation-list-item/action.ts
+++ b/src/app/[locale]/_components/wrap-segments/translation-section/translation-list-item/action.ts
@@ -2,7 +2,7 @@
 import { z } from "zod";
 import { authAndValidate } from "@/app/[locale]/_action/auth-and-validate";
 import type { ActionResponse } from "@/app/types";
-import { revalidatePageTreeAllLocales } from "@/lib/revalidate-utils";
+import { revalidatePageForLocale } from "@/lib/revalidate-utils";
 import { findPageIdBySegmentTranslationId } from "../_db/queries.server";
 import { deleteOwnTranslation } from "./db/mutations.server";
 
@@ -27,7 +27,7 @@ export async function deleteTranslationAction(
 	// Resolve page info BEFORE deletion
 	const pageId = await findPageIdBySegmentTranslationId(translationId);
 	await deleteOwnTranslation(currentUser.handle, translationId);
-	// Revalidate page + parent/children across all locales
-	await revalidatePageTreeAllLocales(pageId);
+	// Revalidate page for the current locale
+	await revalidatePageForLocale(pageId, data.userLocale);
 	return { success: true, data: undefined };
 }

--- a/src/app/[locale]/_components/wrap-segments/translation-section/vote-buttons/action.ts
+++ b/src/app/[locale]/_components/wrap-segments/translation-section/vote-buttons/action.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import type { ActionResponse } from "@/app/types";
 import { getCurrentUser } from "@/lib/auth-server";
 import { parseFormData } from "@/lib/parse-form-data";
-import { revalidatePageTreeAllLocales } from "@/lib/revalidate-utils";
+import { revalidatePageForLocale } from "@/lib/revalidate-utils";
 import { findPageIdBySegmentTranslationId } from "../_db/queries.server";
 import {
 	createNotificationPageSegmentTranslationVote,
@@ -55,10 +55,10 @@ export async function voteTranslationAction(
 		);
 	}
 
-	// Revalidate page + parent/children across all locales
+	// Revalidate page for the current locale
 	const pageId = await findPageIdBySegmentTranslationId(
 		parsedFormData.data.segmentTranslationId,
 	);
-	await revalidatePageTreeAllLocales(pageId);
+	await revalidatePageForLocale(pageId, parsedFormData.data.userLocale);
 	return { success: true, data: { isUpvote, point } };
 }

--- a/src/app/api/translate/chunk/route.ts
+++ b/src/app/api/translate/chunk/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { revalidatePageTreeAllLocales } from "@/lib/revalidate-utils";
+import { revalidatePageForLocale } from "@/lib/revalidate-utils";
 import {
 	incrementTranslationProgress,
 	markJobFailed,
@@ -31,9 +31,9 @@ async function handler(req: Request) {
 			inc,
 		);
 
-		// If the job is completed, revalidate the page and its parent/children.
+		// If the job is completed, revalidate the page.
 		if (updated && updated.status === "COMPLETED") {
-			await revalidatePageTreeAllLocales(params.pageId);
+			await revalidatePageForLocale(params.pageId, params.targetLocale);
 		}
 
 		return NextResponse.json({ ok: true });

--- a/src/app/api/translate/route.ts
+++ b/src/app/api/translate/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { BASE_URL } from "@/app/_constants/base-url";
 import type { TranslateChunkParams } from "@/app/api/translate/types";
-import { revalidatePageTreeAllLocales } from "@/lib/revalidate-utils";
+import { revalidatePageForLocale } from "@/lib/revalidate-utils";
 import { markJobCompleted, markJobInProgress } from "./_db/mutations.server";
 import { splitNumberedElements } from "./_lib/split-numbered-elements.server";
 import { withQstashVerification } from "./_lib/with-qstash-signature";
@@ -33,7 +33,7 @@ async function handler(req: Request) {
 		// If there is nothing to translate, finalize immediately.
 		if (totalChunks === 0) {
 			await markJobCompleted(params.translationJobId);
-			await revalidatePageTreeAllLocales(params.pageId);
+			await revalidatePageForLocale(params.pageId, params.targetLocale);
 			return NextResponse.json({ ok: true }, { status: 201 });
 		}
 

--- a/src/lib/revalidate-utils.ts
+++ b/src/lib/revalidate-utils.ts
@@ -15,6 +15,24 @@ export function revalidateAllLocales(
 }
 
 /**
+ * Revalidate a specific page for a specific locale.
+ * Fetches page info and revalidates only the specified locale path.
+ */
+export async function revalidatePageForLocale(
+	pageId: number,
+	locale: string,
+	revalidateFn: (path: string) => void = revalidatePath,
+) {
+	const page = await prisma.page.findUnique({
+		where: { id: pageId },
+		select: { slug: true, user: { select: { handle: true } } },
+	});
+	if (page) {
+		revalidateFn(`/${locale}/user/${page.user.handle}/page/${page.slug}`);
+	}
+}
+
+/**
  * Revalidate self + all ancestors and all descendants (recursive) across locales.
  * Note: descendants are limited to PUBLIC to match visible routes.
  */


### PR DESCRIPTION
- Changed `directUrl` in the Prisma schema datasource configuration to use `DATABASE_URL_UNPOOLED`.
- Updated revalidation functions to revalidate pages for the current locale instead of all locales across various components and API routes.
- Adjusted revalidation timing for static pages to once per month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **最適化**
  * データベース接続設定を最適化しました。
  * ページの再検証戦略をグローバルからロケール固有の処理に変更し、効率を向上させました。
  * キャッシュ有効期間を1時間から30日に拡張し、スケーラビリティを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->