### PR TITLE
Fix unresponsive floating menu on mobile

### DIFF
--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-keyboard-menu.tsx
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-keyboard-menu.tsx
@@ -126,7 +126,11 @@ export function EditorKeyboardMenu({ editor }: EditorKeyboardMenuProps) {
 								[value]: !prev[value],
 							}));
 						}}
-						onPointerDown={(e) => e.preventDefault()}
+						onPointerDown={(event) => {
+							if (event.pointerType === "mouse") {
+								event.preventDefault();
+							}
+						}}
 						title={label}
 						type="button"
 					>


### PR DESCRIPTION
Limit `preventDefault` on `onPointerDown` to mouse events to fix floating menu buttons not responding on touch devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-707e26ec-57e4-4416-93e0-af64b9c40d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-707e26ec-57e4-4416-93e0-af64b9c40d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

