### PR TITLE
Fix quote block auto line breaks

### DIFF
--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-config.test.ts
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/editor/editor-config.test.ts
@@ -26,6 +26,16 @@ describe("editor-config", () => {
 		it("keeps single <br> inside paragraph", () => {
 			expect(transform("foo<br>bar")).toBe("<p>foo<br>bar</p>");
 		});
+
+		it("keeps existing blockquote markup untouched", () => {
+			const html = "<blockquote><p>Quote text</p></blockquote>";
+			expect(transform(html)).toBe(html);
+		});
+
+		it("splits double <br> inside existing paragraphs without nesting", () => {
+			const html = "<p>foo<br><br>bar</p>";
+			expect(transform(html)).toBe("<p>foo</p><p>bar</p>");
+		});
 	});
 
 	describe("FileHandler onPaste", () => {
@@ -163,8 +173,7 @@ describe("editor-config", () => {
 
 		it("keeps paragraph with real content and converts consecutive br to paragraph break", () => {
 			const html = "<p>foo<br><br>bar</p>";
-			// 連続<br>で段落分割され、空段落は削除される
-			expect(transformFn(html)).toBe("<p><p>foo</p><p>bar</p></p>");
+			expect(transformFn(html)).toBe("<p>foo</p><p>bar</p>");
 		});
 	});
 });


### PR DESCRIPTION
Rework `transformPastedHTML` to prevent incorrect `<p>` wrapping of block elements and improve handling of double `<br>`.

The previous logic indiscriminately wrapped all pasted content in an outer `<p>` tag, which caused existing block elements like `<blockquote>` to be incorrectly nested, leading to unwanted line breaks and reflows after saving. The updated logic now intelligently detects existing block elements and avoids adding an unnecessary outer `<p>`, while still correctly splitting inline content and paragraphs based on double `<br>` sequences.

---
<a href="https://cursor.com/background-agent?bcId=bc-8da4c94c-ca65-438c-8f49-56b9d2d8da66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8da4c94c-ca65-438c-8f49-56b9d2d8da66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

