### PR TITLE
chore: downgrade isomorphic-dompurify version and update subproject commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"hast": "1.0.0",
 		"hast-util-to-html": "9.0.5",
 		"html-react-parser": "5.2.10",
-		"isomorphic-dompurify": "2.32.0",
+		"isomorphic-dompurify": "2.26.0",
 		"linkify-react": "4.3.2",
 		"lucide-react": "0.554.0",
 		"nanoid": "5.1.6",


### PR DESCRIPTION
- Downgraded `isomorphic-dompurify` from version 2.32.0 to 2.26.0 in `package.json` for compatibility.
- Updated the subproject commit for `cst` to reflect a dirty state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

このプルリクエストには、エンドユーザーに対する機能変更や改善はありません。

* **その他の変更**
  * 内部パッケージの調整を行いました。機能に影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->