### PR TITLE
fix: refactor sanitizeAndParseText function to use DOMPurify directly

### DIFF
--- a/src/app/[locale]/_lib/sanitize-and-parse-text.client.ts
+++ b/src/app/[locale]/_lib/sanitize-and-parse-text.client.ts
@@ -1,10 +1,8 @@
 "use client";
 import parse from "html-react-parser";
+import DOMPurify from "isomorphic-dompurify";
 
-export async function sanitizeAndParseText(
-	text: string,
-): Promise<React.ReactNode> {
-	const DOMPurify = (await import("isomorphic-dompurify")).default;
+export function sanitizeAndParseText(text: string): React.ReactNode {
 	const sanitized = DOMPurify.sanitize(
 		text.replace(/(\r\n|\n|\\n)/g, "<br />"),
 	);


### PR DESCRIPTION
- Changed the `sanitizeAndParseText` function to use DOMPurify directly instead of dynamically importing it.
- Removed the async keyword as it is no longer necessary.