### PR TITLE
Enhance TranslationFormOnClick component to prevent UI activation when links are clicked or keyboard keys are pressed within links. Updated tests to verify these behaviors. Added non-interactive property to child page segment elements for improved UI handling.

### DIFF
--- a/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/child-pages/client.tsx
+++ b/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/child-pages/client.tsx
@@ -43,6 +43,7 @@ function PageLink({ page, titleSegment, className }: PageLinkProps) {
 		<Link className={cn("block overflow-hidden", className)} href={pageLink}>
 			<SegmentElement
 				className="line-clamp-1 break-all overflow-wrap-anywhere"
+				interactive={false}
 				segment={titleSegment}
 				tagName="span"
 			/>

--- a/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/translation-form-on-click.client.test.tsx
+++ b/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/translation-form-on-click.client.test.tsx
@@ -46,6 +46,21 @@ describe("TranslationFormOnClick", () => {
 		expect(screen.queryByTestId("tr-ui")).toBeNull();
 	});
 
+	test("リンク内の data-segment-id をクリックしてもUIは開かない（ナビゲーション優先）", async () => {
+		const user = userEvent.setup();
+		render(
+			<>
+				<a className="seg-tr" data-segment-id="123" href="#x">
+					open
+				</a>
+				<TranslationFormOnClick />
+			</>,
+		);
+
+		await user.click(screen.getByText("open"));
+		expect(screen.queryByTestId("tr-ui")).toBeNull();
+	});
+
 	test("同じ段をもう一度クリックすると閉じる（toggle）", async () => {
 		const user = userEvent.setup();
 		render(
@@ -87,6 +102,22 @@ describe("TranslationFormOnClick", () => {
 		expect(screen.queryByTestId("tr-ui")).toBeNull();
 
 		window.getSelection = original;
+	});
+
+	test("リンク内ではキーボード（Enter/Space）でも UI は開かない", async () => {
+		render(
+			<>
+				<a className="seg-tr" data-segment-id="123" href="#x">
+					open
+				</a>
+				<TranslationFormOnClick />
+			</>,
+		);
+
+		const target = screen.getByText("open");
+		fireEvent.keyDown(target, { key: "Enter" });
+		fireEvent.keyDown(target, { key: " " });
+		expect(screen.queryByTestId("tr-ui")).toBeNull();
 	});
 
 	test("キーボード（Enter/Space）で UI を開ける", async () => {

--- a/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/translation-form-on-click.client.tsx
+++ b/src/app/[locale]/(common-layout)/user/[handle]/page/[pageSlug]/_components/translation-form-on-click.client.tsx
@@ -83,6 +83,8 @@ export function TranslationFormOnClick() {
 			const el = target?.closest?.("[data-segment-id]") as HTMLElement | null;
 			if (!el) return;
 			if (!(container as HTMLElement).contains(el)) return;
+			// When segments are wrapped in a link, don't hijack the click (navigation should win).
+			if (el.closest("a")) return;
 			if (hadSelectionOnPointerDownRef.current) return;
 			if (getHasSelection()) return;
 			if (!isClickOnText(e)) return;
@@ -111,6 +113,8 @@ export function TranslationFormOnClick() {
 			const el = target?.closest?.("[data-segment-id]") as HTMLElement | null;
 			if (!el) return;
 			if (!(container as HTMLElement).contains(el)) return;
+			// When segments are wrapped in a link, don't hijack keyboard activation.
+			if (el.closest("a")) return;
 
 			// Prevent page scroll on Space
 			if (e.key === " ") e.preventDefault();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ページセグメント内のリンクをクリックまたはキーボード操作（Enter/Space）で選択した場合、翻訳UIが開かないように改善しました。リンクへのナビゲーションが正常に機能するようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->