### PR TITLE
Refactor translation handling in edit page actions. Update logic to default target locales to ["en", "zh"] when none are specified. Adjust related tests and components to ensure consistent behavior across the application. Update HelpPopover alignment for improved UI presentation.

### DIFF
--- a/src/app/[locale]/(common-layout)/_components/header/help-popover.client.tsx
+++ b/src/app/[locale]/(common-layout)/_components/header/help-popover.client.tsx
@@ -19,7 +19,7 @@ export function HelpPopover({ title, description }: HelpPopoverProps) {
 			<PopoverTrigger asChild>
 				<CircleHelp className="h-6 w-6 cursor-pointer" />
 			</PopoverTrigger>
-			<PopoverContent align="end" className="w-64 rounded-xl p-3 text-sm">
+			<PopoverContent align="center" className="w-64 rounded-xl p-3 text-sm">
 				<p className="font-semibold text-foreground">{title}</p>
 				<div className="mt-1 text-muted-foreground">{description}</div>
 			</PopoverContent>

--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/header/action.integration.test.ts
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/header/action.integration.test.ts
@@ -187,11 +187,42 @@ describe("editPageStatusAction", () => {
 			const formData = new FormData();
 			formData.append("pageId", page.id.toString());
 			formData.append("status", "PUBLIC");
+			formData.append("targetLocales", "");
 
 			const result = await editPageStatusAction({ success: false }, formData);
 
 			expect(result.success).toBe(true);
-			expect(result.success && result.data).toBeUndefined();
+			expect(enqueuePageTranslation).toHaveBeenCalledWith({
+				aiModel: "gemini-2.5-flash-lite",
+				currentUserId: user.id,
+				pageId: page.id,
+				targetLocales: ["en", "zh"],
+			});
+		});
+
+		it("targetLocalesが未指定の場合、デフォルトロケールで翻訳ジョブを作成する", async () => {
+			const user = await createUser({ handle: "testuser" });
+			const page = await createPage({
+				userId: user.id,
+				slug: "test-page",
+				status: "DRAFT",
+			});
+			mockCurrentUser(user);
+			vi.mocked(enqueuePageTranslation).mockResolvedValue([]);
+
+			const formData = new FormData();
+			formData.append("pageId", page.id.toString());
+			formData.append("status", "PUBLIC");
+
+			const result = await editPageStatusAction({ success: false }, formData);
+
+			expect(result.success).toBe(true);
+			expect(enqueuePageTranslation).toHaveBeenCalledWith({
+				aiModel: "gemini-2.5-flash-lite",
+				currentUserId: user.id,
+				pageId: page.id,
+				targetLocales: ["en", "zh"],
+			});
 		});
 	});
 });

--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/header/action.ts
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/header/action.ts
@@ -49,11 +49,11 @@ export async function editPageStatusAction(
 	await updatePageStatus(pageId, status as PageStatus);
 
 	let translationJobs: TranslationJobForToast[] | undefined;
-	if (status === "PUBLIC" && targetLocales.length > 0) {
+	if (status === "PUBLIC") {
 		translationJobs = await enqueuePageTranslation({
 			currentUserId: currentUser.id,
 			pageId,
-			targetLocales,
+			targetLocales: targetLocales.length > 0 ? targetLocales : ["en", "zh"],
 			aiModel: "gemini-2.5-flash-lite",
 		});
 	}

--- a/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/header/client.tsx
+++ b/src/app/[locale]/(edit-layout)/user/[handle]/page/[pageSlug]/edit/_components/header/client.tsx
@@ -144,7 +144,7 @@ export function EditHeader({
 	}, [isPending, isPublic]);
 
 	const [locales, setLocales] = useState<string[]>(
-		targetLocales ?? ["en", "zh"],
+		targetLocales.length > 0 ? targetLocales : ["en", "zh"],
 	);
 	// Determine selectable locale limit (premium users can select up to 4)
 	const maxSelectableLocales =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ヘルプポップオーバーの配置を中央に調整しました。
  * ページを公開する際、翻訳対象言語が指定されていない場合、英語と中国語が自動的にデフォルト設定されるようになりました。

* **テスト**
  * 翻訳キューのデフォルト動作に関するテストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->