### PR TITLE
Add About page hero copy and restructure landing page content

### DIFF
--- a/src/app/[locale]/(common-layout)/[handle]/_components/user-info.server.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/_components/user-info.server.tsx
@@ -46,6 +46,12 @@ export async function UserInfo({
 	const followingList = await fetchFollowingList(pageOwner.id);
 
 	const profileUrl = `${BASE_URL}/${locale}/${pageOwner.handle}`;
+	const avatar = (
+		<Avatar className="w-20 h-20 md:w-24 md:h-24 not-prose">
+			<AvatarImage {...props} />
+			<AvatarFallback>{pageOwner.name.charAt(0).toUpperCase()}</AvatarFallback>
+		</Avatar>
+	);
 
 	return (
 		<>
@@ -59,14 +65,13 @@ export async function UserInfo({
 				<div className="pb-4">
 					<div className="flex w-full flex-col md:flex-row">
 						<div>
-							<Link href={`${pageOwner.image}`}>
-								<Avatar className="w-20 h-20 md:w-24 md:h-24 not-prose">
-									<AvatarImage {...props} />
-									<AvatarFallback>
-										{pageOwner.name.charAt(0).toUpperCase()}
-									</AvatarFallback>
-								</Avatar>
-							</Link>
+							{pageOwner.image ? (
+								<a href={pageOwner.image} rel="noreferrer" target="_blank">
+									{avatar}
+								</a>
+							) : (
+								avatar
+							)}
 						</div>
 						<div className="mt-2 md:mt-0 md:ml-4 flex items-center justify-between w-full">
 							<div>

--- a/src/app/[locale]/(common-layout)/[handle]/edit/_components/profile-form.client.test.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/edit/_components/profile-form.client.test.tsx
@@ -1,0 +1,53 @@
+import { render, waitFor } from "@testing-library/react";
+import { useActionState } from "react";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockUsers } from "@/tests/mock";
+import { ProfileForm } from "./profile-form";
+
+vi.mock("react", async () => {
+	const actual = await vi.importActual<typeof import("react")>("react");
+	return {
+		...actual,
+		useActionState: vi.fn(),
+	};
+});
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/app/[locale]/_service/auth-client", () => ({
+	authClient: { updateUser: vi.fn() },
+}));
+vi.mock("next/image", () => ({
+	__esModule: true,
+	default: (props: { alt?: string; src?: string }) => {
+		const { alt = "", src = "", ...rest } = props;
+		return <span data-alt={alt} data-image="true" data-src={src} {...rest} />;
+	},
+}));
+
+describe("ProfileForm", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("バリデーションエラーがあるとき_最初のメッセージをtoastで表示する", async () => {
+		vi.mocked(useActionState)
+			.mockReturnValueOnce([
+				{ success: false, zodErrors: { name: ["名前が短すぎます"] } },
+				vi.fn(),
+				false,
+			])
+			.mockReturnValueOnce([
+				{ success: true, data: { imageUrl: mockUsers[0].image } },
+				vi.fn(),
+				false,
+			]);
+
+		render(<ProfileForm currentUser={mockUsers[0]} />);
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith("名前が短すぎます");
+		});
+	});
+});

--- a/src/app/[locale]/(common-layout)/[handle]/edit/_components/profile-form.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/edit/_components/profile-form.tsx
@@ -70,12 +70,21 @@ export function ProfileForm({ currentUser }: ProfileFormProps) {
 				await authClient.updateUser({
 					name: editState.data?.name,
 				});
-			} else if (
-				!editState.success &&
-				editState.message &&
-				!editState.zodErrors
-			) {
-				toast.error(editState.message);
+				return;
+			}
+			if (!editState.success) {
+				const errorMessage =
+					editState.zodErrors?.name?.[0] ??
+					editState.zodErrors?.profile?.[0] ??
+					editState.zodErrors?.twitterHandle?.[0] ??
+					editState.zodErrors?.handle?.[0];
+				if (errorMessage) {
+					toast.error(errorMessage);
+					return;
+				}
+				if (editState.message) {
+					toast.error(editState.message);
+				}
 			}
 		};
 

--- a/src/app/[locale]/(common-layout)/[handle]/edit/_components/reserved-handles.json
+++ b/src/app/[locale]/(common-layout)/[handle]/edit/_components/reserved-handles.json
@@ -635,7 +635,6 @@
 	"eveeve-official",
 	"eveeveOfficial",
 	"eveeve-official-blog",
-	"evame",
 	"evame-official",
 	"evameOfficial",
 	"evame-official-blog",

--- a/src/app/[locale]/(common-layout)/[handle]/edit/_components/settings-form.client.test.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/edit/_components/settings-form.client.test.tsx
@@ -1,0 +1,42 @@
+import { render, waitFor } from "@testing-library/react";
+import { useActionState } from "react";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockUsers } from "@/tests/mock";
+import { SettingsForm } from "./settings-form";
+
+vi.mock("react", async () => {
+	const actual = await vi.importActual<typeof import("react")>("react");
+	return {
+		...actual,
+		useActionState: vi.fn(),
+	};
+});
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe("SettingsForm", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("バリデーションエラーがあるとき_最初のメッセージをtoastで表示する", async () => {
+		vi.mocked(useActionState)
+			.mockReturnValueOnce([
+				{
+					success: false,
+					zodErrors: { handle: ["このハンドルは使用できません"] },
+				},
+				vi.fn(),
+				false,
+			])
+			.mockReturnValueOnce([{ success: false }, vi.fn(), false]);
+
+		render(<SettingsForm currentUser={mockUsers[0]} />);
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith("このハンドルは使用できません");
+		});
+	});
+});

--- a/src/app/[locale]/(common-layout)/[handle]/edit/_components/settings-form.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/edit/_components/settings-form.tsx
@@ -31,12 +31,21 @@ export function SettingsForm({ currentUser }: SettingsFormProps) {
 	useEffect(() => {
 		if (editState.success && editState.message) {
 			toast.success(editState.message);
-		} else if (
-			!editState.success &&
-			editState.message &&
-			!editState.zodErrors
-		) {
-			toast.error(editState.message);
+			return;
+		}
+		if (!editState.success) {
+			const errorMessage =
+				editState.zodErrors?.handle?.[0] ??
+				editState.zodErrors?.name?.[0] ??
+				editState.zodErrors?.profile?.[0] ??
+				editState.zodErrors?.twitterHandle?.[0];
+			if (errorMessage) {
+				toast.error(errorMessage);
+				return;
+			}
+			if (editState.message) {
+				toast.error(editState.message);
+			}
 		}
 	}, [editState]);
 


### PR DESCRIPTION
- Introduced a new ADR for the About page hero copy, adopting a user-centric message to enhance conversion rates.
- Created comprehensive LP content copy in both Japanese and English, including sections for hero, social proof, founder story, problem, comparison, FAQ, and final CTA.
- Restructured the landing page layout to optimize for conversion, incorporating new components and updating existing ones.
- Updated global styles to support new content structure and visibility settings for the About section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プロフィール編集フォームのエラーメッセージ表示を改善
  * 設定フォームのエラーメッセージ表示を改善
  * ユーザーアバター表示のロジックを最適化

* **テスト**
  * プロフィール編集フォームのユニットテストを追加
  * 設定フォームのユニットテストを追加

* **その他**
  * 予約済みハンドルリストから"evame"を削除

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->