### PR TITLE
編集画面にフォルダ構造のサイドバーを追加

### DIFF
--- a/src/app/[locale]/(edit-layout)/[handle]/[pageSlug]/edit/_components/edit-page-client/index.tsx
+++ b/src/app/[locale]/(edit-layout)/[handle]/[pageSlug]/edit/_components/edit-page-client/index.tsx
@@ -107,58 +107,91 @@ export function EditPageClient({
 				targetLocales={targetLocales}
 				translationContexts={translationContexts}
 			/>
-			<main className="px-4 grow ">
-				<div
-					className="w-full max-w-3xl prose dark:prose-invert sm:prose lg:prose-lg
+			<main className="px-4 grow">
+				<div className="mx-auto w-full max-w-5xl lg:flex lg:gap-8">
+					<aside className="mt-4 lg:mt-6 lg:w-64 shrink-0">
+						<div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/40 p-3">
+							<p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+								フォルダ
+							</p>
+							<div className="mt-3">
+								<div className="flex items-center gap-2 text-sm font-medium text-gray-800 dark:text-gray-100">
+									<span className="inline-flex h-5 w-5 items-center justify-center rounded bg-gray-100 dark:bg-gray-800">
+										📁
+									</span>
+									<span className="truncate">
+										{title.trim() || "未命名のフォルダ"}
+									</span>
+								</div>
+								<ul className="mt-2 space-y-1 border-l border-gray-200 dark:border-gray-700 pl-6 text-sm text-gray-600 dark:text-gray-300">
+									<li className="flex items-center gap-2 font-medium text-gray-800 dark:text-gray-100">
+										<span className="text-base">📝</span>
+										<span>記事</span>
+									</li>
+									<li className="flex items-center gap-2">
+										<span className="text-base">📂</span>
+										<span>関連資料</span>
+									</li>
+									<li className="flex items-center gap-2">
+										<span className="text-base">📂</span>
+										<span>Plans</span>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</aside>
+					<div
+						className="w-full max-w-3xl prose dark:prose-invert sm:prose lg:prose-lg
         mx-auto  prose-headings:text-gray-700 dark:prose-headings:text-gray-200 text-gray-700 dark:text-gray-200 mb-5 mt-3 md:mt-5 tracking-wider"
-				>
-					<div className="">
-						<h1 className="m-0! ">
-							<TextareaAutosize
-								className="w-full outline-hidden bg-transparent resize-none overflow-hidden"
-								data-testid="title-input"
-								maxRows={10}
-								minRows={1}
-								name="title"
-								onChange={handleTitleChange}
-								onKeyDown={handleTitleKeyDown}
-								placeholder="Title"
-								value={title}
+					>
+						<div className="">
+							<h1 className="m-0! ">
+								<TextareaAutosize
+									className="w-full outline-hidden bg-transparent resize-none overflow-hidden"
+									data-testid="title-input"
+									maxRows={10}
+									minRows={1}
+									name="title"
+									onChange={handleTitleChange}
+									onKeyDown={handleTitleKeyDown}
+									placeholder="Title"
+									value={title}
+								/>
+							</h1>
+							{!editState.success && editState.zodErrors?.title && (
+								<p className="text-sm text-red-500">
+									{editState.zodErrors.title}
+								</p>
+							)}
+							<TagInput
+								allTagsWithCount={allTagsWithCount}
+								initialTags={
+									pageWithTitleAndTags?.tagPages.map((tagPage) => ({
+										name: tagPage.tag.name,
+									})) || []
+								}
+								pageId={pageWithTitleAndTags?.id}
 							/>
-						</h1>
-						{!editState.success && editState.zodErrors?.title && (
+						</div>
+						<form action={editAction} ref={formRef}>
+							<input name="pageSlug" type="hidden" value={pageSlug} />
+							<input name="title" type="hidden" value={title} />
+							<input name="userLocale" type="hidden" value={userLocale} />
+							<Editor
+								className="outline-hidden"
+								defaultValue={html}
+								name="pageContent"
+								onEditorCreate={setEditorInstance}
+								onEditorUpdate={handleChange}
+								placeholder="Write to the world..."
+							/>
+						</form>
+						{!editState.success && editState.zodErrors?.pageContent && (
 							<p className="text-sm text-red-500">
-								{editState.zodErrors.title}
+								{editState.zodErrors.pageContent}
 							</p>
 						)}
-						<TagInput
-							allTagsWithCount={allTagsWithCount}
-							initialTags={
-								pageWithTitleAndTags?.tagPages.map((tagPage) => ({
-									name: tagPage.tag.name,
-								})) || []
-							}
-							pageId={pageWithTitleAndTags?.id}
-						/>
 					</div>
-					<form action={editAction} ref={formRef}>
-						<input name="pageSlug" type="hidden" value={pageSlug} />
-						<input name="title" type="hidden" value={title} />
-						<input name="userLocale" type="hidden" value={userLocale} />
-						<Editor
-							className="outline-hidden"
-							defaultValue={html}
-							name="pageContent"
-							onEditorCreate={setEditorInstance}
-							onEditorUpdate={handleChange}
-							placeholder="Write to the world..."
-						/>
-					</form>
-					{!editState.success && editState.zodErrors?.pageContent && (
-						<p className="text-sm text-red-500">
-							{editState.zodErrors.pageContent}
-						</p>
-					)}
 				</div>
 			</main>
 			{editorInstance && <EditorKeyboardMenu editor={editorInstance} />}


### PR DESCRIPTION
### Motivation
- 編集画面で記事・関連資料・Plans の配置を分かりやすくするため、編集中にフォルダ構造を視覚化するナビゲーションが必要だった。 

### Description
- `src/app/[locale]/(edit-layout)/[handle]/[pageSlug]/edit/_components/edit-page-client/index.tsx` にサイドバー用の `aside` を追加しフォルダ名（タイトル）と `記事` / `関連資料` / `Plans` を表示するUIを実装した。 
- レイアウトをレスポンシブに調整するため、ラッパーを `mx-auto w-full max-w-5xl lg:flex lg:gap-8` に変更してメインコンテンツとサイドバーを並べるようにした。 
- 既存のタイトル入力、タグ入力、Editor フォームのロジックは維持しつつ見た目のみを整理して最小限の変更にとどめた。 

### Testing
- `bun run biome` を実行してコードスタイル/静的チェックを行い問題は検出されず成功した。 
- `bun run typecheck` を実行したが型定義ファイルが不足して失敗しており、依存インストール時に `@tiptap-pro` レジストリからの取得で `403` が発生したため解決が必要。 
- 開発サーバーを起動してページを自動で取得・スクリーンショットする簡易 E2E を実行しスクリーンショットは取得できたが、環境の `Edge Config` 接続文字列が未設定のため一部ルートが `404` になっていることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dcde0619083268719d555d3d2cf07)