### PR TITLE
ページ本文のMarkdown出力を追加

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,8 @@
         "kysely": "0.28.10",
         "linkify-react": "4.3.2",
         "lucide-react": "0.563.0",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-to-markdown": "^2.1.2",
         "nanoid": "5.1.6",
         "next": "16.1.4",
         "next-intl": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
 		"kysely": "0.28.10",
 		"linkify-react": "4.3.2",
 		"lucide-react": "0.563.0",
+		"mdast-util-gfm": "^3.1.0",
+		"mdast-util-to-markdown": "^2.1.2",
 		"nanoid": "5.1.6",
 		"next": "16.1.4",
 		"next-intl": "4.7.0",

--- a/src/app/[locale]/(common-layout)/[handle]/[pageSlug]/_components/export-markdown-button.client.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/[pageSlug]/_components/export-markdown-button.client.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { DownloadIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ExportMarkdownButtonProps {
+	markdown: string;
+	title: string;
+	slug: string;
+}
+
+function toSafeFileName(value: string) {
+	const trimmed = value.trim();
+	const safe = trimmed
+		.replace(/[\\/:*?"<>|]/g, "-")
+		.replace(/\s+/g, "-")
+		.replace(/-+/g, "-");
+	return safe.length > 0 ? safe : "page";
+}
+
+export function ExportMarkdownButton({
+	markdown,
+	title,
+	slug,
+}: ExportMarkdownButtonProps) {
+	const hasContent = markdown.trim().length > 0;
+	const baseName = toSafeFileName(title || slug);
+	const fileName = `${baseName}.md`;
+
+	const handleClick = () => {
+		if (!hasContent) return;
+		const blob = new Blob([markdown], {
+			type: "text/markdown;charset=utf-8",
+		});
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = fileName;
+		document.body.appendChild(link);
+		link.click();
+		link.remove();
+		URL.revokeObjectURL(url);
+	};
+
+	return (
+		<Button
+			aria-label="Markdownを出力"
+			disabled={!hasContent}
+			onClick={handleClick}
+			size="sm"
+			variant="outline"
+		>
+			<DownloadIcon className="mr-2 h-4 w-4" />
+			Markdownを出力
+		</Button>
+	);
+}

--- a/src/app/[locale]/(common-layout)/[handle]/[pageSlug]/_components/page-content.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/[pageSlug]/_components/page-content.tsx
@@ -2,6 +2,7 @@ import { EyeIcon, MessageCircle } from "lucide-react";
 import { BASE_URL } from "@/app/_constants/base-url";
 import { fetchPageCounts } from "@/app/[locale]/_db/fetch-page-detail.server";
 import { fetchPageViewCount } from "@/app/[locale]/_db/page-utility-queries.server";
+import { mdastToMarkdown } from "@/app/[locale]/_domain/mdast-to-markdown";
 import { mdastToText } from "@/app/[locale]/_domain/mdast-to-text";
 import { FloatingControls } from "@/app/[locale]/(common-layout)/_components/floating-controls/floating-controls.client";
 import { PageLikeButtonClient } from "@/app/[locale]/(common-layout)/_components/page/page-like-button/client";
@@ -11,6 +12,7 @@ import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/seo/json-ld";
 import { ChildPages } from "./child-pages/server";
 import { PageCommentForm } from "./comment/_components/page-comment-form/client";
 import { ContentWithTranslations } from "./content-with-translations";
+import { ExportMarkdownButton } from "./export-markdown-button.client";
 import { PageNavigation } from "./page-navigation/server";
 import { PageViewCounter } from "./page-view-counter/client";
 import { PreviewBanner } from "./preview-banner";
@@ -46,6 +48,7 @@ export async function PageContent({ pageDetail, locale }: PageContentProps) {
 			collectAnnotationTypes(pageDetail.segments),
 			mdastToText(pageDetail.mdastJson).then((text) => text.slice(0, 200)),
 		]);
+	const markdown = mdastToMarkdown(pageDetail.mdastJson);
 	const isDraft = pageDetail.status !== "PUBLIC";
 
 	const articleUrl = `${BASE_URL}/${pageDetail.sourceLocale}/${pageDetail.userHandle}/${pageDetail.slug}`;
@@ -79,7 +82,7 @@ export async function PageContent({ pageDetail, locale }: PageContentProps) {
 			<PageNavigation locale={locale} pageId={pageDetail.id} />
 			<ContentWithTranslations pageDetail={pageDetail} />
 			<ChildPages locale={locale} parentId={pageDetail.id} />
-			<div className="flex items-center gap-4">
+			<div className="flex flex-wrap items-center gap-4">
 				<EyeIcon className="w-5 h-5" strokeWidth={1.5} />
 				<PageViewCounter
 					className="text-muted-foreground"
@@ -94,6 +97,11 @@ export async function PageContent({ pageDetail, locale }: PageContentProps) {
 				/>
 				<MessageCircle className="w-5 h-5" strokeWidth={1.5} />
 				<span className="text-muted-foreground">{pageCounts.pageComments}</span>
+				<ExportMarkdownButton
+					markdown={markdown}
+					slug={pageDetail.slug}
+					title={pageDetail.title}
+				/>
 			</div>
 
 			<FloatingControls

--- a/src/app/[locale]/_domain/mdast-to-markdown.ts
+++ b/src/app/[locale]/_domain/mdast-to-markdown.ts
@@ -1,0 +1,32 @@
+import type { Root } from "mdast";
+import { gfmToMarkdown } from "mdast-util-gfm";
+import { toMarkdown } from "mdast-util-to-markdown";
+import type { JsonValue } from "@/db/types";
+
+function toRoot(mdastJson: JsonValue): Root | null {
+	if (mdastJson == null) return null;
+	if (typeof mdastJson !== "object") return null;
+	if (Array.isArray(mdastJson)) {
+		return {
+			type: "root",
+			children: mdastJson as unknown as Root["children"],
+		};
+	}
+	return mdastJson as unknown as Root;
+}
+
+export function mdastToMarkdown(mdastJson: JsonValue): string {
+	if (mdastJson == null) return "";
+	if (typeof mdastJson === "string") return mdastJson;
+	if (typeof mdastJson === "number" || typeof mdastJson === "boolean")
+		return String(mdastJson);
+
+	const root = toRoot(mdastJson);
+	if (!root) return "";
+
+	try {
+		return toMarkdown(root, { extensions: [gfmToMarkdown()] });
+	} catch {
+		return "";
+	}
+}


### PR DESCRIPTION
## 概要\n- ページ本文をMarkdownとして出力できるボタンを追加\n- mdast(JSON)からMarkdownへの変換ユーティリティを追加\n\n## 確認\n- [x] bun run typecheck\n- [x] bun run biome\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * マークダウンエクスポート機能を追加しました。ページのコンテンツをマークダウン形式（.md ファイル）でダウンロードできるようになります。ページの操作エリアに追加されたボタンから利用できます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->