### PR TITLE
perf: add page indexes and optimize tag list

### DIFF
--- a/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.integration.test.ts
+++ b/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.integration.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "@/db";
+import { resetDatabase } from "@/tests/db-helpers";
+import { createPageWithSegments, createUser } from "@/tests/factories";
+import { setupDbPerFile } from "@/tests/test-db-manager";
+import { fetchPaginatedPublicNewestPageListsByTag } from "./queries.server";
+
+await setupDbPerFile(import.meta.url);
+
+async function attachTag(pageId: number, name: string) {
+	const existing = await db
+		.selectFrom("tags")
+		.selectAll()
+		.where("name", "=", name)
+		.executeTakeFirst();
+
+	const tag =
+		existing ??
+		(await db
+			.insertInto("tags")
+			.values({ name })
+			.returningAll()
+			.executeTakeFirstOrThrow());
+
+	await db.insertInto("tagPages").values({ tagId: tag.id, pageId }).execute();
+}
+
+async function setCreatedAt(pageId: number, createdAt: Date) {
+	await db
+		.updateTable("pages")
+		.set({ createdAt })
+		.where("id", "=", pageId)
+		.execute();
+}
+
+describe("fetchPaginatedPublicNewestPageListsByTag", () => {
+	beforeEach(async () => {
+		await resetDatabase();
+	});
+
+	it("タグ別の新着ページを作成日時の降順で返す", async () => {
+		const user = await createUser();
+
+		const pageOld = await createPageWithSegments({
+			userId: user.id,
+			slug: "ai-old",
+			segments: [
+				{
+					number: 0,
+					text: "Old Title",
+					textAndOccurrenceHash: "hash-old",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const pageMid = await createPageWithSegments({
+			userId: user.id,
+			slug: "ai-mid",
+			segments: [
+				{
+					number: 0,
+					text: "Mid Title",
+					textAndOccurrenceHash: "hash-mid",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const pageNew = await createPageWithSegments({
+			userId: user.id,
+			slug: "ai-new",
+			segments: [
+				{
+					number: 0,
+					text: "New Title",
+					textAndOccurrenceHash: "hash-new",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const pageOther = await createPageWithSegments({
+			userId: user.id,
+			slug: "other-tag",
+			segments: [
+				{
+					number: 0,
+					text: "Other Title",
+					textAndOccurrenceHash: "hash-other",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+
+		await attachTag(pageOld.id, "AI");
+		await attachTag(pageMid.id, "AI");
+		await attachTag(pageNew.id, "AI");
+		await attachTag(pageOther.id, "Other");
+
+		const base = new Date("2026-02-05T00:00:00.000Z");
+		await setCreatedAt(pageOld.id, new Date(base.getTime() - 60_000));
+		await setCreatedAt(pageMid.id, new Date(base.getTime() - 30_000));
+		await setCreatedAt(pageNew.id, new Date(base.getTime()));
+		await setCreatedAt(pageOther.id, new Date(base.getTime() + 10_000));
+
+		const first = await fetchPaginatedPublicNewestPageListsByTag({
+			tagName: "AI",
+			page: 1,
+			pageSize: 2,
+			locale: "en",
+		});
+
+		expect(first.totalPages).toBe(2);
+		expect(first.pageForLists.map((page) => page.slug)).toEqual([
+			"ai-new",
+			"ai-mid",
+		]);
+
+		const second = await fetchPaginatedPublicNewestPageListsByTag({
+			tagName: "AI",
+			page: 2,
+			pageSize: 2,
+			locale: "en",
+		});
+
+		expect(second.pageForLists.map((page) => page.slug)).toEqual(["ai-old"]);
+	});
+});

--- a/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.ts
+++ b/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.ts
@@ -1,5 +1,10 @@
-import { searchPagesByTag } from "@/app/[locale]/_db/page-search.server";
+import {
+	buildPageListQuery,
+	fetchTagsMap,
+	toPageForList,
+} from "@/app/[locale]/_db/page-list.server";
 import type { PageForList } from "@/app/[locale]/types";
+import { db } from "@/db";
 
 export interface FetchPaginatedNewestPagesByTagParams {
 	tagName: string;
@@ -20,17 +25,38 @@ export async function fetchPaginatedPublicNewestPageListsByTag({
 	pageForLists: PageForList[];
 	totalPages: number;
 }> {
-	const skip = (page - 1) * pageSize;
+	const offset = (page - 1) * pageSize;
 
-	const { pageForLists, total } = await searchPagesByTag(
-		tagName,
-		skip,
-		pageSize,
-		locale,
+	const [rows, totalResult] = await Promise.all([
+		buildPageListQuery(locale)
+			.innerJoin("tagPages", "tagPages.pageId", "pages.id")
+			.innerJoin("tags", "tagPages.tagId", "tags.id")
+			.where("tags.name", "=", tagName)
+			.where("pages.status", "=", "PUBLIC")
+			.orderBy("pages.createdAt", "desc")
+			.limit(pageSize)
+			.offset(offset)
+			.execute(),
+		db
+			.selectFrom("tagPages")
+			.innerJoin("tags", "tagPages.tagId", "tags.id")
+			.innerJoin("pages", "tagPages.pageId", "pages.id")
+			.select((eb) =>
+				eb.fn.count<number>("tagPages.pageId").distinct().as("count"),
+			)
+			.where("tags.name", "=", tagName)
+			.where("pages.status", "=", "PUBLIC")
+			.executeTakeFirst(),
+	]);
+
+	const pageIds = rows.map((row) => row.id);
+	const tagsMap = await fetchTagsMap(pageIds);
+	const pageForLists = rows.map((row) =>
+		toPageForList(row, tagsMap.get(row.id) || []),
 	);
 
 	return {
 		pageForLists,
-		totalPages: Math.ceil(total / pageSize),
+		totalPages: Math.ceil(Number(totalResult?.count ?? 0) / pageSize),
 	};
 }

--- a/src/drizzle/0014_closed_justice.sql
+++ b/src/drizzle/0014_closed_justice.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "pages_status_created_at_idx" ON "pages" USING btree ("status","created_at");--> statement-breakpoint
+CREATE INDEX "pages_status_parent_id_created_at_idx" ON "pages" USING btree ("status","parent_id","created_at");

--- a/src/drizzle/meta/0014_snapshot.json
+++ b/src/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2738 @@
+{
+	"id": "1c00c637-9e0e-4ea4-8075-d6e127ae8dea",
+	"prevId": "ab3f46fb-aade-44b8-a630-01d1e0cd40c9",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.accounts": {
+			"name": "accounts",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"accounts_provider_accountId_key": {
+					"name": "accounts_provider_accountId_key",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "account_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"accounts_userId_fkey": {
+					"name": "accounts_userId_fkey",
+					"tableFrom": "accounts",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.contents": {
+			"name": "contents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "content_kind",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"import_file_id": {
+					"name": "import_file_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"contents_kind_idx": {
+					"name": "contents_kind_idx",
+					"columns": [
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"contents_import_file_id_fkey": {
+					"name": "contents_import_file_id_fkey",
+					"tableFrom": "contents",
+					"tableTo": "import_files",
+					"columnsFrom": ["import_file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.follows": {
+			"name": "follows",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"follower_id": {
+					"name": "follower_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"following_id": {
+					"name": "following_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"follows_follower_id_idx": {
+					"name": "follows_follower_id_idx",
+					"columns": [
+						{
+							"expression": "follower_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"follows_following_id_idx": {
+					"name": "follows_following_id_idx",
+					"columns": [
+						{
+							"expression": "following_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"follows_follower_id_fkey": {
+					"name": "follows_follower_id_fkey",
+					"tableFrom": "follows",
+					"tableTo": "users",
+					"columnsFrom": ["follower_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"follows_following_id_fkey": {
+					"name": "follows_following_id_fkey",
+					"tableFrom": "follows",
+					"tableTo": "users",
+					"columnsFrom": ["following_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"follows_follower_id_following_id_key": {
+					"name": "follows_follower_id_following_id_key",
+					"nullsNotDistinct": false,
+					"columns": ["follower_id", "following_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gemini_api_keys": {
+			"name": "gemini_api_keys",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"api_key": {
+					"name": "api_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"gemini_api_keys_user_id_idx": {
+					"name": "gemini_api_keys_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gemini_api_keys_user_id_key": {
+					"name": "gemini_api_keys_user_id_key",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gemini_api_keys_user_id_fkey": {
+					"name": "gemini_api_keys_user_id_fkey",
+					"tableFrom": "gemini_api_keys",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.import_files": {
+			"name": "import_files",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"import_run_id": {
+					"name": "import_run_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"path": {
+					"name": "path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"checksum": {
+					"name": "checksum",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"import_files_import_run_id_fkey": {
+					"name": "import_files_import_run_id_fkey",
+					"tableFrom": "import_files",
+					"tableTo": "import_runs",
+					"columnsFrom": ["import_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.import_runs": {
+			"name": "import_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'RUNNING'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.like_pages": {
+			"name": "like_pages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"page_id": {
+					"name": "page_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"like_pages_page_id_idx": {
+					"name": "like_pages_page_id_idx",
+					"columns": [
+						{
+							"expression": "page_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"like_pages_user_id_idx": {
+					"name": "like_pages_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"like_pages_user_id_page_id_key": {
+					"name": "like_pages_user_id_page_id_key",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "page_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"like_pages_page_id_fkey": {
+					"name": "like_pages_page_id_fkey",
+					"tableFrom": "like_pages",
+					"tableTo": "pages",
+					"columnsFrom": ["page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"like_pages_user_id_fkey": {
+					"name": "like_pages_user_id_fkey",
+					"tableFrom": "like_pages",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.notifications": {
+			"name": "notifications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "notification_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"read": {
+					"name": "read",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"actor_id": {
+					"name": "actor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"page_comment_id": {
+					"name": "page_comment_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"page_id": {
+					"name": "page_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"segment_translation_id": {
+					"name": "segment_translation_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"notifications_actor_id_idx": {
+					"name": "notifications_actor_id_idx",
+					"columns": [
+						{
+							"expression": "actor_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"notifications_user_id_idx": {
+					"name": "notifications_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"notifications_actor_id_fkey": {
+					"name": "notifications_actor_id_fkey",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["actor_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"notifications_page_comment_id_fkey": {
+					"name": "notifications_page_comment_id_fkey",
+					"tableFrom": "notifications",
+					"tableTo": "page_comments",
+					"columnsFrom": ["page_comment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				},
+				"notifications_page_id_fkey": {
+					"name": "notifications_page_id_fkey",
+					"tableFrom": "notifications",
+					"tableTo": "pages",
+					"columnsFrom": ["page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				},
+				"notifications_segment_translation_id_fkey": {
+					"name": "notifications_segment_translation_id_fkey",
+					"tableFrom": "notifications",
+					"tableTo": "segment_translations",
+					"columnsFrom": ["segment_translation_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				},
+				"notifications_user_id_fkey": {
+					"name": "notifications_user_id_fkey",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_comments": {
+			"name": "page_comments",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"page_id": {
+					"name": "page_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mdast_json": {
+					"name": "mdast_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_deleted": {
+					"name": "is_deleted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"last_reply_at": {
+					"name": "last_reply_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reply_count": {
+					"name": "reply_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"page_comments_page_id_parent_id_created_at_idx": {
+					"name": "page_comments_page_id_parent_id_created_at_idx",
+					"columns": [
+						{
+							"expression": "page_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "parent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"page_comments_parent_id_is_deleted_created_at_idx": {
+					"name": "page_comments_parent_id_is_deleted_created_at_idx",
+					"columns": [
+						{
+							"expression": "parent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "is_deleted",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"page_comments_user_id_idx": {
+					"name": "page_comments_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"page_comments_id_fkey": {
+					"name": "page_comments_id_fkey",
+					"tableFrom": "page_comments",
+					"tableTo": "contents",
+					"columnsFrom": ["id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"page_comments_page_id_fkey": {
+					"name": "page_comments_page_id_fkey",
+					"tableFrom": "page_comments",
+					"tableTo": "pages",
+					"columnsFrom": ["page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"page_comments_parent_id_fkey": {
+					"name": "page_comments_parent_id_fkey",
+					"tableFrom": "page_comments",
+					"tableTo": "page_comments",
+					"columnsFrom": ["parent_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				},
+				"page_comments_user_id_fkey": {
+					"name": "page_comments_user_id_fkey",
+					"tableFrom": "page_comments",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_locale_translation_proofs": {
+			"name": "page_locale_translation_proofs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"page_id": {
+					"name": "page_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"translation_proof_status": {
+					"name": "translation_proof_status",
+					"type": "translation_proof_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'MACHINE_DRAFT'"
+				}
+			},
+			"indexes": {
+				"page_locale_translation_proofs_page_id_locale_key": {
+					"name": "page_locale_translation_proofs_page_id_locale_key",
+					"columns": [
+						{
+							"expression": "page_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "locale",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"page_locale_translation_proofs_translation_proof_status_idx": {
+					"name": "page_locale_translation_proofs_translation_proof_status_idx",
+					"columns": [
+						{
+							"expression": "translation_proof_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"page_locale_translation_proofs_page_id_fkey": {
+					"name": "page_locale_translation_proofs_page_id_fkey",
+					"tableFrom": "page_locale_translation_proofs",
+					"tableTo": "pages",
+					"columnsFrom": ["page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_views": {
+			"name": "page_views",
+			"schema": "",
+			"columns": {
+				"page_id": {
+					"name": "page_id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"count": {
+					"name": "count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"page_views_pageId_fkey": {
+					"name": "page_views_pageId_fkey",
+					"tableFrom": "page_views",
+					"tableTo": "pages",
+					"columnsFrom": ["page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pages": {
+			"name": "pages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"source_locale": {
+					"name": "source_locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'unknown'"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"status": {
+					"name": "status",
+					"type": "page_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'DRAFT'"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"mdast_json": {
+					"name": "mdast_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"order": {
+					"name": "order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"pages_created_at_idx": {
+					"name": "pages_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pages_status_created_at_idx": {
+					"name": "pages_status_created_at_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pages_status_parent_id_created_at_idx": {
+					"name": "pages_status_parent_id_created_at_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "parent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pages_parent_id_idx": {
+					"name": "pages_parent_id_idx",
+					"columns": [
+						{
+							"expression": "parent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pages_parent_id_order_idx": {
+					"name": "pages_parent_id_order_idx",
+					"columns": [
+						{
+							"expression": "parent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "order",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pages_slug_idx": {
+					"name": "pages_slug_idx",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pages_slug_key": {
+					"name": "pages_slug_key",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pages_user_id_idx": {
+					"name": "pages_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"pages_id_fkey": {
+					"name": "pages_id_fkey",
+					"tableFrom": "pages",
+					"tableTo": "contents",
+					"columnsFrom": ["id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"pages_parent_id_fkey": {
+					"name": "pages_parent_id_fkey",
+					"tableFrom": "pages",
+					"tableTo": "pages",
+					"columnsFrom": ["parent_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				},
+				"pages_user_id_fkey": {
+					"name": "pages_user_id_fkey",
+					"tableFrom": "pages",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.segment_annotation_links": {
+			"name": "segment_annotation_links",
+			"schema": "",
+			"columns": {
+				"main_segment_id": {
+					"name": "main_segment_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"annotation_segment_id": {
+					"name": "annotation_segment_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"segment_annotation_links_annotation_segment_id_idx": {
+					"name": "segment_annotation_links_annotation_segment_id_idx",
+					"columns": [
+						{
+							"expression": "annotation_segment_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segment_annotation_links_main_segment_id_idx": {
+					"name": "segment_annotation_links_main_segment_id_idx",
+					"columns": [
+						{
+							"expression": "main_segment_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"segment_annotation_links_annotation_segment_id_fkey": {
+					"name": "segment_annotation_links_annotation_segment_id_fkey",
+					"tableFrom": "segment_annotation_links",
+					"tableTo": "segments",
+					"columnsFrom": ["annotation_segment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"segment_annotation_links_main_segment_id_fkey": {
+					"name": "segment_annotation_links_main_segment_id_fkey",
+					"tableFrom": "segment_annotation_links",
+					"tableTo": "segments",
+					"columnsFrom": ["main_segment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"segment_annotation_links_pkey": {
+					"name": "segment_annotation_links_pkey",
+					"columns": ["main_segment_id", "annotation_segment_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.segment_metadata": {
+			"name": "segment_metadata",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"segment_id": {
+					"name": "segment_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metadata_type_id": {
+					"name": "metadata_type_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"segment_metadata_metadata_type_id_idx": {
+					"name": "segment_metadata_metadata_type_id_idx",
+					"columns": [
+						{
+							"expression": "metadata_type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segment_metadata_segment_id_idx": {
+					"name": "segment_metadata_segment_id_idx",
+					"columns": [
+						{
+							"expression": "segment_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segment_metadata_segment_id_metadata_type_id_value_key": {
+					"name": "segment_metadata_segment_id_metadata_type_id_value_key",
+					"columns": [
+						{
+							"expression": "segment_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "metadata_type_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "value",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"segment_metadata_metadata_type_id_fkey": {
+					"name": "segment_metadata_metadata_type_id_fkey",
+					"tableFrom": "segment_metadata",
+					"tableTo": "segment_metadata_types",
+					"columnsFrom": ["metadata_type_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"segment_metadata_segment_id_fkey": {
+					"name": "segment_metadata_segment_id_fkey",
+					"tableFrom": "segment_metadata",
+					"tableTo": "segments",
+					"columnsFrom": ["segment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.segment_metadata_types": {
+			"name": "segment_metadata_types",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"segment_metadata_types_key_key": {
+					"name": "segment_metadata_types_key_key",
+					"columns": [
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.segment_translations": {
+			"name": "segment_translations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"segment_id": {
+					"name": "segment_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"text": {
+					"name": "text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"point": {
+					"name": "point",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"segment_translations_segment_id_locale_idx": {
+					"name": "segment_translations_segment_id_locale_idx",
+					"columns": [
+						{
+							"expression": "segment_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "locale",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segment_translations_user_id_idx": {
+					"name": "segment_translations_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"segment_translations_segment_id_fkey": {
+					"name": "segment_translations_segment_id_fkey",
+					"tableFrom": "segment_translations",
+					"tableTo": "segments",
+					"columnsFrom": ["segment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"segment_translations_user_id_fkey": {
+					"name": "segment_translations_user_id_fkey",
+					"tableFrom": "segment_translations",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.segment_types": {
+			"name": "segment_types",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key": {
+					"name": "key",
+					"type": "segment_type_key",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"segment_types_key_idx": {
+					"name": "segment_types_key_idx",
+					"columns": [
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segment_types_key_label_key": {
+					"name": "segment_types_key_label_key",
+					"columns": [
+						{
+							"expression": "key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segment_types_label_idx": {
+					"name": "segment_types_label_idx",
+					"columns": [
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.segments": {
+			"name": "segments",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"content_id": {
+					"name": "content_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"number": {
+					"name": "number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"text": {
+					"name": "text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"text_and_occurrence_hash": {
+					"name": "text_and_occurrence_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"segment_type_id": {
+					"name": "segment_type_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"segments_content_id_idx": {
+					"name": "segments_content_id_idx",
+					"columns": [
+						{
+							"expression": "content_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segments_content_id_number_key": {
+					"name": "segments_content_id_number_key",
+					"columns": [
+						{
+							"expression": "content_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "number",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segments_content_id_text_and_occurrence_hash_key": {
+					"name": "segments_content_id_text_and_occurrence_hash_key",
+					"columns": [
+						{
+							"expression": "content_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "text_and_occurrence_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"segments_text_and_occurrence_hash_idx": {
+					"name": "segments_text_and_occurrence_hash_idx",
+					"columns": [
+						{
+							"expression": "text_and_occurrence_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"segments_content_id_fkey": {
+					"name": "segments_content_id_fkey",
+					"tableFrom": "segments",
+					"tableTo": "contents",
+					"columnsFrom": ["content_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"segments_segment_type_id_fkey": {
+					"name": "segments_segment_type_id_fkey",
+					"tableFrom": "segments",
+					"tableTo": "segment_types",
+					"columnsFrom": ["segment_type_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sessions": {
+			"name": "sessions",
+			"schema": "",
+			"columns": {
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"sessions_token_key": {
+					"name": "sessions_token_key",
+					"columns": [
+						{
+							"expression": "token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"sessions_userId_fkey": {
+					"name": "sessions_userId_fkey",
+					"tableFrom": "sessions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tag_pages": {
+			"name": "tag_pages",
+			"schema": "",
+			"columns": {
+				"tag_id": {
+					"name": "tag_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"page_id": {
+					"name": "page_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"tag_pages_pageId_idx": {
+					"name": "tag_pages_pageId_idx",
+					"columns": [
+						{
+							"expression": "page_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tag_pages_tagId_idx": {
+					"name": "tag_pages_tagId_idx",
+					"columns": [
+						{
+							"expression": "tag_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tag_pages_pageId_fkey": {
+					"name": "tag_pages_pageId_fkey",
+					"tableFrom": "tag_pages",
+					"tableTo": "pages",
+					"columnsFrom": ["page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"tag_pages_tagId_fkey": {
+					"name": "tag_pages_tagId_fkey",
+					"tableFrom": "tag_pages",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"tag_pages_pkey": {
+					"name": "tag_pages_pkey",
+					"columns": ["tag_id", "page_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tags": {
+			"name": "tags",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"tags_name_idx": {
+					"name": "tags_name_idx",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tags_name_key": {
+					"name": "tags_name_key",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.translation_contexts": {
+			"name": "translation_contexts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"context": {
+					"name": "context",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"translation_contexts_user_id_idx": {
+					"name": "translation_contexts_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"translation_contexts_user_id_fkey": {
+					"name": "translation_contexts_user_id_fkey",
+					"tableFrom": "translation_contexts",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.translation_jobs": {
+			"name": "translation_jobs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"page_id": {
+					"name": "page_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ai_model": {
+					"name": "ai_model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "translation_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"progress": {
+					"name": "progress",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"translation_jobs_userId_idx": {
+					"name": "translation_jobs_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"translation_jobs_pageId_fkey": {
+					"name": "translation_jobs_pageId_fkey",
+					"tableFrom": "translation_jobs",
+					"tableTo": "pages",
+					"columnsFrom": ["page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"translation_jobs_userId_fkey": {
+					"name": "translation_jobs_userId_fkey",
+					"tableFrom": "translation_jobs",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.translation_votes": {
+			"name": "translation_votes",
+			"schema": "",
+			"columns": {
+				"translation_id": {
+					"name": "translation_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_upvote": {
+					"name": "is_upvote",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"translation_votes_translation_id_idx": {
+					"name": "translation_votes_translation_id_idx",
+					"columns": [
+						{
+							"expression": "translation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"translation_votes_translation_id_user_id_key": {
+					"name": "translation_votes_translation_id_user_id_key",
+					"columns": [
+						{
+							"expression": "translation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"translation_votes_user_id_idx": {
+					"name": "translation_votes_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"translation_votes_translation_id_fkey": {
+					"name": "translation_votes_translation_id_fkey",
+					"tableFrom": "translation_votes",
+					"tableTo": "segment_translations",
+					"columnsFrom": ["translation_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"translation_votes_user_id_fkey": {
+					"name": "translation_votes_user_id_fkey",
+					"tableFrom": "translation_votes",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_settings": {
+			"name": "user_settings",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_locales": {
+					"name": "target_locales",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"RAY\"}'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_settings_user_id_key": {
+					"name": "user_settings_user_id_key",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_settings_user_id_fkey": {
+					"name": "user_settings_user_id_fkey",
+					"tableFrom": "user_settings",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'https://evame.tech/avatar.png'"
+				},
+				"plan": {
+					"name": "plan",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'free'"
+				},
+				"total_points": {
+					"name": "total_points",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_ai": {
+					"name": "is_ai",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'Credentials'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'new_user'"
+				},
+				"handle": {
+					"name": "handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"profile": {
+					"name": "profile",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"twitter_handle": {
+					"name": "twitter_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"users_email_key": {
+					"name": "users_email_key",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"users_handle_key": {
+					"name": "users_handle_key",
+					"columns": [
+						{
+							"expression": "handle",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verifications": {
+			"name": "verifications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp (3)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.content_kind": {
+			"name": "content_kind",
+			"schema": "public",
+			"values": ["PAGE", "PAGE_COMMENT"]
+		},
+		"public.notification_type": {
+			"name": "notification_type",
+			"schema": "public",
+			"values": [
+				"FOLLOW",
+				"PAGE_COMMENT",
+				"PAGE_LIKE",
+				"PAGE_SEGMENT_TRANSLATION_VOTE",
+				"PAGE_COMMENT_SEGMENT_TRANSLATION_VOTE"
+			]
+		},
+		"public.page_status": {
+			"name": "page_status",
+			"schema": "public",
+			"values": ["DRAFT", "PUBLIC", "ARCHIVE"]
+		},
+		"public.segment_type_key": {
+			"name": "segment_type_key",
+			"schema": "public",
+			"values": ["PRIMARY", "COMMENTARY"]
+		},
+		"public.translation_proof_status": {
+			"name": "translation_proof_status",
+			"schema": "public",
+			"values": ["MACHINE_DRAFT", "HUMAN_TOUCHED", "PROOFREAD", "VALIDATED"]
+		},
+		"public.translation_status": {
+			"name": "translation_status",
+			"schema": "public",
+			"values": ["PENDING", "IN_PROGRESS", "COMPLETED", "FAILED"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
 			"when": 1768928765521,
 			"tag": "0013_gorgeous_ender_wiggin",
 			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1770275693057,
+			"tag": "0014_closed_justice",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -683,6 +683,17 @@ export const pages = pgTable(
 			"btree",
 			table.createdAt.asc().nullsLast(),
 		),
+		index("pages_status_created_at_idx").using(
+			"btree",
+			table.status.asc().nullsLast(),
+			table.createdAt.asc().nullsLast(),
+		),
+		index("pages_status_parent_id_created_at_idx").using(
+			"btree",
+			table.status.asc().nullsLast(),
+			table.parentId.asc().nullsLast(),
+			table.createdAt.asc().nullsLast(),
+		),
 		index("pages_parent_id_idx").using(
 			"btree",
 			table.parentId.asc().nullsLast(),


### PR DESCRIPTION
## Summary
- add composite indexes for pages status/parent/created_at
- optimize tag newest list query with DB-side pagination
- add integration test for tag newest list

## Testing
- bun run typecheck
- bun run biome
- COMPOSE_PROJECT_NAME=eveeve bun run test -- "src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.integration.test.ts"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * タグで検索したページリストのページネーション機能を追加しました。ページサイズとページ番号を指定して、より効率的にコンテンツを閲覧できるようになります。

* **パフォーマンス向上**
  * データベースクエリの最適化のため、新しいインデックスを追加しました。ページリスト取得時の応答速度が向上します。

* **テスト**
  * タグ別ページリスト取得機能のサーバー統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->