### PR TITLE
perf: cache social proof stats

### DIFF
--- a/src/app/[locale]/(common-layout)/_components/about-section/components/social-proof-bar.tsx
+++ b/src/app/[locale]/(common-layout)/_components/about-section/components/social-proof-bar.tsx
@@ -1,4 +1,5 @@
 import { sql } from "kysely";
+import { cacheLife } from "next/cache";
 import { SegmentElement } from "@/app/[locale]/(common-layout)/_components/wrap-segments/segment";
 import { db } from "@/db";
 import { SEGMENT_NUMBER } from "@/db/seed-data/content";
@@ -8,6 +9,9 @@ import { fetchAboutPage } from "../service/fetch-about-page";
 const LANGUAGE_COUNT = 18;
 
 async function fetchSocialProofStats() {
+	"use cache";
+	cacheLife("days");
+
 	const articlesResult = await db
 		.selectFrom("pages")
 		.select(sql<number>`count(*)::int`.as("count"))


### PR DESCRIPTION
## Summary
- cache social proof stats for 1 day to reduce DB load on top page

## Testing
- bun run typecheck
- bun run biome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * ソーシャルプルーフセクションの統計読み込み処理を最適化し、ページの読み込み速度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->