### PR TITLE
perf: aggregate tag page lists

### DIFF
--- a/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.integration.test.ts
+++ b/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.integration.test.ts
@@ -3,7 +3,10 @@ import { db } from "@/db";
 import { resetDatabase } from "@/tests/db-helpers";
 import { createPageWithSegments, createUser } from "@/tests/factories";
 import { setupDbPerFile } from "@/tests/test-db-manager";
-import { fetchPaginatedPublicNewestPageListsByTag } from "./queries.server";
+import {
+	fetchPaginatedPublicNewestPageListsByTag,
+	fetchPublicNewestPageListsByTags,
+} from "./queries.server";
 
 await setupDbPerFile(import.meta.url);
 
@@ -122,5 +125,140 @@ describe("fetchPaginatedPublicNewestPageListsByTag", () => {
 		});
 
 		expect(second.pageForLists.map((page) => page.slug)).toEqual(["ai-old"]);
+	});
+});
+
+describe("fetchPublicNewestPageListsByTags", () => {
+	beforeEach(async () => {
+		await resetDatabase();
+	});
+
+	it("複数タグの新着ページをタグごとにまとめて返す", async () => {
+		const user = await createUser();
+
+		const aiOld = await createPageWithSegments({
+			userId: user.id,
+			slug: "ai-old",
+			segments: [
+				{
+					number: 0,
+					text: "AI Old",
+					textAndOccurrenceHash: "hash-ai-old",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const aiNew = await createPageWithSegments({
+			userId: user.id,
+			slug: "ai-new",
+			segments: [
+				{
+					number: 0,
+					text: "AI New",
+					textAndOccurrenceHash: "hash-ai-new",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const aiNewest = await createPageWithSegments({
+			userId: user.id,
+			slug: "ai-newest",
+			segments: [
+				{
+					number: 0,
+					text: "AI Newest",
+					textAndOccurrenceHash: "hash-ai-newest",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+
+		const progOld = await createPageWithSegments({
+			userId: user.id,
+			slug: "prog-old",
+			segments: [
+				{
+					number: 0,
+					text: "Prog Old",
+					textAndOccurrenceHash: "hash-prog-old",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const progNew = await createPageWithSegments({
+			userId: user.id,
+			slug: "prog-new",
+			segments: [
+				{
+					number: 0,
+					text: "Prog New",
+					textAndOccurrenceHash: "hash-prog-new",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const progNewest = await createPageWithSegments({
+			userId: user.id,
+			slug: "prog-newest",
+			segments: [
+				{
+					number: 0,
+					text: "Prog Newest",
+					textAndOccurrenceHash: "hash-prog-newest",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+		const other = await createPageWithSegments({
+			userId: user.id,
+			slug: "other-tag",
+			segments: [
+				{
+					number: 0,
+					text: "Other",
+					textAndOccurrenceHash: "hash-other",
+					segmentTypeKey: "PRIMARY",
+				},
+			],
+		});
+
+		await attachTag(aiOld.id, "AI");
+		await attachTag(aiNew.id, "AI");
+		await attachTag(aiNewest.id, "AI");
+		await attachTag(progOld.id, "Programming");
+		await attachTag(progNew.id, "Programming");
+		await attachTag(progNewest.id, "Programming");
+		await attachTag(other.id, "Other");
+
+		const base = new Date("2026-02-05T00:00:00.000Z");
+		await setCreatedAt(aiOld.id, new Date(base.getTime() - 50_000));
+		await setCreatedAt(aiNew.id, new Date(base.getTime() - 30_000));
+		await setCreatedAt(aiNewest.id, new Date(base.getTime() - 10_000));
+
+		await setCreatedAt(progOld.id, new Date(base.getTime() - 40_000));
+		await setCreatedAt(progNew.id, new Date(base.getTime() - 20_000));
+		await setCreatedAt(progNewest.id, new Date(base.getTime()));
+
+		await setCreatedAt(other.id, new Date(base.getTime() + 10_000));
+
+		const result = await fetchPublicNewestPageListsByTags({
+			tagNames: ["AI", "Programming"],
+			pageSize: 2,
+			locale: "en",
+		});
+
+		expect(result.map((entry) => entry.tagName)).toEqual(["AI", "Programming"]);
+
+		const aiResult = result.find((entry) => entry.tagName === "AI");
+		const progResult = result.find((entry) => entry.tagName === "Programming");
+
+		expect(aiResult?.pageForLists.map((page) => page.slug)).toEqual([
+			"ai-newest",
+			"ai-new",
+		]);
+		expect(progResult?.pageForLists.map((page) => page.slug)).toEqual([
+			"prog-newest",
+			"prog-new",
+		]);
 	});
 });

--- a/src/app/[locale]/(common-layout)/page.tsx
+++ b/src/app/[locale]/(common-layout)/page.tsx
@@ -5,7 +5,7 @@ import { type ReactNode, Suspense } from "react";
 import { buildAlternates } from "@/app/_lib/seo-helpers";
 import AboutSection from "@/app/[locale]/(common-layout)/_components/about-section/server";
 import NewPageList from "@/app/[locale]/(common-layout)/_components/page/new-page-list/server";
-import NewPageListByTag from "@/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/server";
+import { NewPageListByTags } from "@/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/server";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Link } from "@/i18n/routing";
@@ -65,11 +65,22 @@ function SectionSkeleton({ className }: { className: string }) {
 	return <Skeleton className={className} />;
 }
 
+function TagSectionsSkeleton() {
+	return (
+		<div className="flex flex-col gap-8">
+			<SectionSkeleton className="h-[400px] w-full" />
+			<SectionSkeleton className="h-[400px] w-full" />
+			<SectionSkeleton className="h-[400px] w-full" />
+		</div>
+	);
+}
+
 export default async function HomePage(
 	props: PageProps<"/[locale]">,
 ): Promise<ReactNode> {
 	const { locale } = await props.params;
 	await loadSearchParams(props.searchParams);
+	const tagNames = ["AI", "Programming", "Plurality"];
 	return (
 		<div className="flex flex-col gap-8 justify-between mb-12">
 			<Suspense fallback={<SectionSkeleton className="h-[480px] w-full" />}>
@@ -90,38 +101,9 @@ export default async function HomePage(
 				</Button>
 			</div>
 
-			<Suspense fallback={<SectionSkeleton className="h-[400px] w-full" />}>
-				<NewPageListByTag locale={locale} tagName="AI" />
+			<Suspense fallback={<TagSectionsSkeleton />}>
+				<NewPageListByTags locale={locale} tagNames={tagNames} />
 			</Suspense>
-			<div className="flex justify-center">
-				<Button className="rounded-full w-40 h-10" variant="default">
-					<Link className="flex items-center gap-2" href="/tag/AI">
-						More <ArrowRightIcon className="w-4 h-4" />
-					</Link>
-				</Button>
-			</div>
-
-			<Suspense fallback={<SectionSkeleton className="h-[400px] w-full" />}>
-				<NewPageListByTag locale={locale} tagName="Programming" />
-			</Suspense>
-			<div className="flex justify-center">
-				<Button className="rounded-full w-40 h-10" variant="default">
-					<Link className="flex items-center gap-2" href="/tag/Programming">
-						More <ArrowRightIcon className="w-4 h-4" />
-					</Link>
-				</Button>
-			</div>
-
-			<Suspense fallback={<SectionSkeleton className="h-[400px] w-full" />}>
-				<NewPageListByTag locale={locale} tagName="Plurality" />
-			</Suspense>
-			<div className="flex justify-center">
-				<Button className="rounded-full w-40 h-10" variant="default">
-					<Link className="flex items-center gap-2" href="/tag/Plurality">
-						More <ArrowRightIcon className="w-4 h-4" />
-					</Link>
-				</Button>
-			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- aggregate tag newest lists into a single query for top page
- add multi-tag query API and tests

## Testing
- bun run typecheck
- bun run biome
- COMPOSE_PROJECT_NAME=eveeve bun run test -- "src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.integration.test.ts"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* 複数のタグに基づくページリストを同時に表示する機能が追加されました
* 複数のタグセクションの読み込みが統合され、ローディング体験が向上しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->