### PR TITLE
perf: batch page view counts

### DIFF
--- a/src/app/[locale]/(common-layout)/[handle]/_components/user-page-list.server.tsx
+++ b/src/app/[locale]/(common-layout)/[handle]/_components/user-page-list.server.tsx
@@ -5,6 +5,7 @@ import {
 	fetchPaginatedNewPageLists,
 	fetchPaginatedPopularPageLists,
 } from "@/app/[locale]/_db/page-list.server";
+import { fetchPageViewCounts } from "@/app/[locale]/_db/page-utility-queries.server";
 import { PageLikeListClient } from "@/app/[locale]/(common-layout)/_components/page/page-like-button/like-list.client";
 import { PageList } from "@/app/[locale]/(common-layout)/_components/page/page-list.server";
 import { PaginationBar } from "@/app/[locale]/(common-layout)/_components/pagination-bar";
@@ -44,6 +45,7 @@ export async function PageListServer({
 		pageOwnerId: pageOwner.id,
 		locale,
 	});
+	const viewCounts = await fetchPageViewCounts(pageForLists.map((p) => p.id));
 	if (pageForLists.length === 0) {
 		return (
 			<p className="text-center text-gray-500 mt-10">
@@ -62,6 +64,7 @@ export async function PageListServer({
 						locale={locale}
 						PageForList={PageForList}
 						showOwnerActions={isOwner}
+						viewCount={viewCounts.get(PageForList.id) ?? 0}
 					/>
 				))}
 			</div>

--- a/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/server.tsx
@@ -2,6 +2,7 @@ import { ArrowRightIcon, SparklesIcon } from "lucide-react";
 import type { SearchParams } from "nuqs/server";
 import { createLoader, parseAsInteger } from "nuqs/server";
 import { Fragment } from "react";
+import { fetchPageViewCounts } from "@/app/[locale]/_db/page-utility-queries.server";
 import { PageLikeListClient } from "@/app/[locale]/(common-layout)/_components/page/page-like-button/like-list.client";
 import { PageList } from "@/app/[locale]/(common-layout)/_components/page/page-list.server";
 import { PageListContainer } from "@/app/[locale]/(common-layout)/_components/page/page-list-container/server";
@@ -38,6 +39,7 @@ interface TagPageListSectionProps {
 	currentPage: number;
 	totalPages: number;
 	showPagination: boolean;
+	viewCounts: Map<number, number>;
 }
 
 function TagPageListSection({
@@ -47,6 +49,7 @@ function TagPageListSection({
 	currentPage,
 	totalPages,
 	showPagination,
+	viewCounts,
 }: TagPageListSectionProps) {
 	if (pageForLists.length === 0) {
 		return null;
@@ -61,6 +64,7 @@ function TagPageListSection({
 					key={PageForList.id}
 					locale={locale}
 					PageForList={PageForList}
+					viewCount={viewCounts.get(PageForList.id) ?? 0}
 				/>
 			))}
 			{showPagination && totalPages > 1 && (
@@ -89,6 +93,7 @@ export default async function NewPageListByTag({
 			pageSize: 5,
 			locale,
 		});
+	const viewCounts = await fetchPageViewCounts(pageForLists.map((p) => p.id));
 
 	return (
 		<TagPageListSection
@@ -98,6 +103,7 @@ export default async function NewPageListByTag({
 			showPagination={showPagination}
 			tagName={tagName}
 			totalPages={totalPages}
+			viewCounts={viewCounts}
 		/>
 	);
 }
@@ -118,6 +124,10 @@ export async function NewPageListByTags({
 		pageSize,
 		locale,
 	});
+	const pageIds = tagPageLists.flatMap((list) =>
+		list.pageForLists.map((page) => page.id),
+	);
+	const viewCounts = await fetchPageViewCounts(pageIds);
 
 	return (
 		<>
@@ -130,6 +140,7 @@ export async function NewPageListByTags({
 						showPagination={false}
 						tagName={tagName}
 						totalPages={1}
+						viewCounts={viewCounts}
 					/>
 					<div className="flex justify-center">
 						<Button className="rounded-full w-40 h-10" variant="default">

--- a/src/app/[locale]/(common-layout)/_components/page/new-page-list/server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/new-page-list/server.tsx
@@ -2,6 +2,7 @@ import { SparklesIcon } from "lucide-react";
 import type { SearchParams } from "nuqs/server";
 import { createLoader, parseAsInteger } from "nuqs/server";
 import { fetchPaginatedNewPageLists } from "@/app/[locale]/_db/page-list.server";
+import { fetchPageViewCounts } from "@/app/[locale]/_db/page-utility-queries.server";
 import { PageListContainer } from "@/app/[locale]/(common-layout)/_components/page/page-list-container/server";
 import { PaginationBar } from "@/app/[locale]/(common-layout)/_components/pagination-bar";
 import { PageLikeListClient } from "../page-like-button/like-list.client";
@@ -31,6 +32,7 @@ export default async function NewPageList({
 		pageSize: 5,
 		locale,
 	});
+	const viewCounts = await fetchPageViewCounts(pageForLists.map((p) => p.id));
 
 	return (
 		<PageListContainer icon={SparklesIcon} title="New Pages">
@@ -41,6 +43,7 @@ export default async function NewPageList({
 					key={PageForList.id}
 					locale={locale}
 					PageForList={PageForList}
+					viewCount={viewCounts.get(PageForList.id) ?? 0}
 				/>
 			))}
 			{showPagination && totalPages > 1 && (

--- a/src/app/[locale]/(common-layout)/_components/page/page-list.server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/page-list.server.tsx
@@ -1,7 +1,6 @@
 import { EyeIcon } from "lucide-react";
 import { getImageProps } from "next/image";
 import { BASE_URL } from "@/app/_constants/base-url";
-import { fetchPageViewCount } from "@/app/[locale]/_db/page-utility-queries.server";
 import { PageLikeButton } from "@/app/[locale]/(common-layout)/_components/page/page-like-button/server";
 import { PageTagList } from "@/app/[locale]/(common-layout)/_components/page/page-tag-list";
 import { SegmentElement } from "@/app/[locale]/(common-layout)/_components/wrap-segments/segment";
@@ -16,13 +15,15 @@ type PageListProps = {
 	showOwnerActions?: boolean;
 	index?: number;
 	locale: string;
+	viewCount: number;
 };
 
-export async function PageList({
+export function PageList({
 	PageForList,
 	showOwnerActions = false,
 	index,
 	locale,
+	viewCount,
 }: PageListProps) {
 	const { props } = getImageProps({
 		src: PageForList.userImage,
@@ -35,7 +36,6 @@ export async function PageList({
 		`${BASE_URL}/api/og?locale=${locale}` + `&slug=${PageForList.slug}`;
 	const pageLink = `/${PageForList.userHandle}/${PageForList.slug}`;
 	const userLink = `/${PageForList.userHandle}`;
-	const viewCount = await fetchPageViewCount(PageForList.id);
 	return (
 		<article
 			className={`grid gap-4 py-4 border-b last:border-b-0 ${

--- a/src/app/[locale]/(common-layout)/_components/page/popular-page-list-by-tag/server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/popular-page-list-by-tag/server.tsx
@@ -3,6 +3,7 @@
 import { BookOpenIcon } from "lucide-react";
 import type { SearchParams } from "nuqs/server";
 import { createLoader, parseAsInteger } from "nuqs/server";
+import { fetchPageViewCounts } from "@/app/[locale]/_db/page-utility-queries.server";
 import { PageLikeListClient } from "@/app/[locale]/(common-layout)/_components/page/page-like-button/like-list.client";
 import { PageList } from "@/app/[locale]/(common-layout)/_components/page/page-list.server";
 import { PageListContainer } from "@/app/[locale]/(common-layout)/_components/page/page-list-container/server";
@@ -44,6 +45,7 @@ export default async function PopularPageListByTag({
 			locale,
 		},
 	);
+	const viewCounts = await fetchPageViewCounts(pageForLists.map((p) => p.id));
 
 	if (pageForLists.length === 0) {
 		return null;
@@ -58,6 +60,7 @@ export default async function PopularPageListByTag({
 					key={PageForList.id}
 					locale={locale}
 					PageForList={PageForList}
+					viewCount={viewCounts.get(PageForList.id) ?? 0}
 				/>
 			))}
 			{showPagination && totalPages > 1 && (

--- a/src/app/[locale]/(common-layout)/_components/page/popular-page-list/server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/popular-page-list/server.tsx
@@ -2,6 +2,7 @@ import { BookOpenIcon } from "lucide-react";
 import type { SearchParams } from "nuqs/server";
 import { createLoader, parseAsInteger } from "nuqs/server";
 import { fetchPaginatedPopularPageLists } from "@/app/[locale]/_db/page-list.server";
+import { fetchPageViewCounts } from "@/app/[locale]/_db/page-utility-queries.server";
 import { PageLikeListClient } from "@/app/[locale]/(common-layout)/_components/page/page-like-button/like-list.client";
 import { PaginationBar } from "@/app/[locale]/(common-layout)/_components/pagination-bar";
 import { PageList } from "../page-list.server";
@@ -31,6 +32,7 @@ export default async function PopularPageList({
 		pageSize: 5,
 		locale,
 	});
+	const viewCounts = await fetchPageViewCounts(pageForLists.map((p) => p.id));
 
 	return (
 		<PageListContainer icon={BookOpenIcon} title="Popular Pages">
@@ -41,6 +43,7 @@ export default async function PopularPageList({
 					key={PageForList.id}
 					locale={locale}
 					PageForList={PageForList}
+					viewCount={viewCounts.get(PageForList.id) ?? 0}
 				/>
 			))}
 			{showPagination && totalPages > 1 && (

--- a/src/app/[locale]/(common-layout)/search/page.tsx
+++ b/src/app/[locale]/(common-layout)/search/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { createLoader, parseAsInteger, parseAsString } from "nuqs/server";
 import type React from "react";
 import { buildAlternates } from "@/app/_lib/seo-helpers";
+import { fetchPageViewCounts } from "@/app/[locale]/_db/page-utility-queries.server";
 import { fetchSearchResults } from "./_db/queries.server";
 import { CATEGORIES, type Category } from "./constants";
 import { SearchPageClient } from "./search.client";
@@ -81,6 +82,9 @@ export default async function SearchPage(
 		locale,
 		tagPage,
 	});
+	const pageViewCounts = await fetchPageViewCounts(
+		pageSummaries?.map((summary) => summary.id) ?? [],
+	);
 
 	return (
 		<main>
@@ -93,6 +97,7 @@ export default async function SearchPage(
 							currentPage={page}
 							locale={locale}
 							pageSummaries={pageSummaries}
+							pageViewCounts={pageViewCounts}
 							tags={tags}
 							totalPages={totalPages}
 							users={users}

--- a/src/app/[locale]/(common-layout)/search/search-results.server.tsx
+++ b/src/app/[locale]/(common-layout)/search/search-results.server.tsx
@@ -8,6 +8,7 @@ import type { Category } from "./constants";
 
 interface SearchResultsProps {
 	pageSummaries: PageForList[] | undefined;
+	pageViewCounts: Map<number, number>;
 	tags: Tag[] | undefined;
 	users: SanitizedUser[] | undefined;
 	totalPages: number;
@@ -18,6 +19,7 @@ interface SearchResultsProps {
 
 export function SearchResults({
 	pageSummaries,
+	pageViewCounts,
 	tags,
 	users,
 	totalPages,
@@ -49,7 +51,12 @@ export function SearchResults({
 							<PageLikeListClient pageIds={pageSummaries.map((p) => p.id)} />
 							<div className="space-y-4">
 								{pageSummaries.map((p) => (
-									<PageList key={p.id} locale={locale} PageForList={p} />
+									<PageList
+										key={p.id}
+										locale={locale}
+										PageForList={p}
+										viewCount={pageViewCounts.get(p.id) ?? 0}
+									/>
 								))}
 							</div>
 						</>
@@ -77,7 +84,12 @@ export function SearchResults({
 							<PageLikeListClient pageIds={pageSummaries.map((p) => p.id)} />
 							<div className="space-y-4">
 								{pageSummaries.map((p) => (
-									<PageList key={p.id} locale={locale} PageForList={p} />
+									<PageList
+										key={p.id}
+										locale={locale}
+										PageForList={p}
+										viewCount={pageViewCounts.get(p.id) ?? 0}
+									/>
 								))}
 							</div>
 						</>

--- a/src/app/[locale]/_db/page-utility-queries.server.integration.test.ts
+++ b/src/app/[locale]/_db/page-utility-queries.server.integration.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { db } from "@/db";
+import { resetDatabase } from "@/tests/db-helpers";
+import { createPage, createUser } from "@/tests/factories";
+import { setupDbPerFile } from "@/tests/test-db-manager";
+import { fetchPageViewCounts } from "./page-utility-queries.server";
+
+await setupDbPerFile(import.meta.url);
+
+describe("fetchPageViewCounts", () => {
+	beforeEach(async () => {
+		await resetDatabase();
+	});
+
+	it("ページIDごとの閲覧数をまとめて返す", async () => {
+		const user = await createUser();
+		const pageA = await createPage({ userId: user.id, slug: "page-a" });
+		const pageB = await createPage({ userId: user.id, slug: "page-b" });
+
+		await db
+			.insertInto("pageViews")
+			.values([
+				{ pageId: pageA.id, count: 12 },
+				{ pageId: pageB.id, count: 0 },
+			])
+			.execute();
+
+		const result = await fetchPageViewCounts([pageA.id, pageB.id, pageA.id]);
+
+		expect(result.get(pageA.id)).toBe(12);
+		expect(result.get(pageB.id)).toBe(0);
+	});
+});

--- a/src/app/[locale]/_db/page-utility-queries.server.ts
+++ b/src/app/[locale]/_db/page-utility-queries.server.ts
@@ -43,3 +43,28 @@ export async function fetchPageViewCount(pageId: number): Promise<number> {
 		.executeTakeFirst();
 	return result?.count ?? 0;
 }
+
+/**
+ * ページの閲覧数をまとめて取得
+ */
+export async function fetchPageViewCounts(pageIds: number[]) {
+	const uniqueIds = Array.from(new Set(pageIds));
+	const counts = new Map<number, number>();
+	if (uniqueIds.length === 0) return counts;
+
+	for (const id of uniqueIds) {
+		counts.set(id, 0);
+	}
+
+	const rows = await db
+		.selectFrom("pageViews")
+		.select(["pageId", "count"])
+		.where("pageId", "in", uniqueIds)
+		.execute();
+
+	for (const row of rows) {
+		counts.set(row.pageId, row.count);
+	}
+
+	return counts;
+}


### PR DESCRIPTION
## Summary
- batch page view counts to avoid N+1 queries across page lists
- update list components and search results to pass view counts
- add integration test for bulk view count fetch

## Testing
- bun run typecheck
- bun run biome
- COMPOSE_PROJECT_NAME=eveeve bun run test -- "src/app/[locale]/_db/page-utility-queries.server.integration.test.ts" "src/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/_db/queries.server.integration.test.ts"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ページビュー数の表示機能をページリスト全体に追加しました。

* **改善**
  * ページビュー数の取得方法を最適化し、複数ページの情報を一度に取得するよう改善しました。

* **テスト**
  * ページビュー数取得機能の統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->