### PR TITLE
トップページをNew/Popular構成に簡素化

### DIFF
--- a/src/app/[locale]/(common-layout)/page.tsx
+++ b/src/app/[locale]/(common-layout)/page.tsx
@@ -5,7 +5,7 @@ import { type ReactNode, Suspense } from "react";
 import { buildAlternates } from "@/app/_lib/seo-helpers";
 import AboutSection from "@/app/[locale]/(common-layout)/_components/about-section/server";
 import NewPageList from "@/app/[locale]/(common-layout)/_components/page/new-page-list/server";
-import { NewPageListByTags } from "@/app/[locale]/(common-layout)/_components/page/new-page-list-by-tag/server";
+import PopularPageList from "@/app/[locale]/(common-layout)/_components/page/popular-page-list/server";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Link } from "@/i18n/routing";
@@ -65,22 +65,11 @@ function SectionSkeleton({ className }: { className: string }) {
 	return <Skeleton className={className} />;
 }
 
-function TagSectionsSkeleton() {
-	return (
-		<div className="flex flex-col gap-8">
-			<SectionSkeleton className="h-[400px] w-full" />
-			<SectionSkeleton className="h-[400px] w-full" />
-			<SectionSkeleton className="h-[400px] w-full" />
-		</div>
-	);
-}
-
 export default async function HomePage(
 	props: PageProps<"/[locale]">,
 ): Promise<ReactNode> {
 	const { locale } = await props.params;
 	await loadSearchParams(props.searchParams);
-	const tagNames = ["AI", "Programming", "Plurality"];
 	return (
 		<div className="flex flex-col gap-8 justify-between mb-12">
 			<Suspense fallback={<SectionSkeleton className="h-[480px] w-full" />}>
@@ -101,8 +90,8 @@ export default async function HomePage(
 				</Button>
 			</div>
 
-			<Suspense fallback={<TagSectionsSkeleton />}>
-				<NewPageListByTags locale={locale} tagNames={tagNames} />
+			<Suspense fallback={<SectionSkeleton className="h-[400px] w-full" />}>
+				<PopularPageList locale={locale} searchParams={props.searchParams} />
 			</Suspense>
 		</div>
 	);


### PR DESCRIPTION
## 変更内容
- トップページのタグ別一覧（`NewPageListByTags`）を削除
- 代わりに `PopularPageList` を表示
- フォールバックをタグ用複数スケルトンから単一セクション用スケルトンへ簡素化

## 影響範囲
- topページのみ
- 変更ファイル: `src/app/[locale]/(common-layout)/page.tsx`

## 確認
- `bun run biome`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ホームページの表示コンテンツを更新しました。タグベースのページリストから人気ページリストに切り替え、ユーザーがより人気のあるコンテンツを簡単に発見できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->