### PR TITLE
refactor: Update editor bubble menu to subscribe to selectionUpdate event instead of transaction

### DIFF
--- a/src/app/[locale]/(edit-layout)/[handle]/[pageSlug]/edit/_components/editor/editor-bubble-menu.client.tsx
+++ b/src/app/[locale]/(edit-layout)/[handle]/[pageSlug]/edit/_components/editor/editor-bubble-menu.client.tsx
@@ -66,14 +66,13 @@ function useEditorStore(editor: TiptapEditor) {
 				counterRef.current++;
 				cb();
 			};
-			editor.on("transaction", handler);
+			editor.on("selectionUpdate", handler);
 			return () => {
-				editor.off("transaction", handler);
+				editor.off("selectionUpdate", handler);
 			};
 		},
 		[editor],
 	);
-
 	useSyncExternalStore(subscribe, () => counterRef.current);
 }
 

--- a/src/app/[locale]/(edit-layout)/[handle]/[pageSlug]/edit/_components/editor/editor-menu-position.test.tsx
+++ b/src/app/[locale]/(edit-layout)/[handle]/[pageSlug]/edit/_components/editor/editor-menu-position.test.tsx
@@ -90,6 +90,8 @@ vi.mock("@tiptap/react/menus", () => ({
 }));
 
 function createEditorMock() {
+	const on = vi.fn();
+	const off = vi.fn();
 	const chainResult = {
 		focus: () => chainResult,
 		setParagraph: () => chainResult,
@@ -111,8 +113,8 @@ function createEditorMock() {
 		chain: () => chainResult,
 		getAttributes: () => ({}),
 		isActive: () => false,
-		off: vi.fn(),
-		on: vi.fn(),
+		off,
+		on,
 		state: {
 			selection: {
 				empty: false,
@@ -163,5 +165,20 @@ describe("editor menu position", () => {
 			"data-side-offset",
 			"6",
 		);
+	});
+
+	it("BubbleMenuはselectionUpdateのみを購読する", () => {
+		const editor = createEditorMock();
+		const { unmount } = render(<EditorBubbleMenu editor={editor as never} />);
+
+		const subscribedEvents = editor.on.mock.calls.map(([event]) => event);
+		expect(subscribedEvents).toContain("selectionUpdate");
+		expect(subscribedEvents).not.toContain("transaction");
+
+		unmount();
+
+		const unsubscribedEvents = editor.off.mock.calls.map(([event]) => event);
+		expect(unsubscribedEvents).toContain("selectionUpdate");
+		expect(unsubscribedEvents).not.toContain("transaction");
 	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * エディター バブル メニューのイベント購読動作を検証する テストを追加しました。

* **Refactor**
  * エディターの イベント購読メカニズムを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->