### PR TITLE
feat: クッキー同意バナーを追加してGAを同意後に読み込む

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -38,5 +38,12 @@
 			"untranslatedTitle": "Untranslated",
 			"untranslatedDescription": "Not translated yet."
 		}
+	},
+	"CookieConsent": {
+		"title": "Allow cookies?",
+		"description": "We use cookies to provide and improve Evame.",
+		"accept": "Allow",
+		"decline": "Decline",
+		"privacyLink": "Privacy Policy"
 	}
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -38,5 +38,12 @@
 			"untranslatedTitle": "Sin traducir",
 			"untranslatedDescription": "Aún no se ha traducido."
 		}
+	},
+	"CookieConsent": {
+		"title": "¿Permitir cookies?",
+		"description": "Usamos cookies para ofrecer y mejorar Evame.",
+		"accept": "Permitir",
+		"decline": "No permitir",
+		"privacyLink": "Política de privacidad"
 	}
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -38,5 +38,12 @@
 			"untranslatedTitle": "未翻訳",
 			"untranslatedDescription": "まだ翻訳されていません。"
 		}
+	},
+	"CookieConsent": {
+		"title": "Cookieを許可しますか？",
+		"description": "Evameではサービス提供と改善のためにCookieを使用します。",
+		"accept": "許可",
+		"decline": "許可しない",
+		"privacyLink": "プライバシーポリシー"
 	}
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -38,5 +38,12 @@
 			"untranslatedTitle": "미번역",
 			"untranslatedDescription": "아직 번역되지 않았습니다."
 		}
+	},
+	"CookieConsent": {
+		"title": "쿠키를 허용할까요?",
+		"description": "Evame는 서비스 제공과 개선을 위해 쿠키를 사용합니다.",
+		"accept": "허용",
+		"decline": "허용 안 함",
+		"privacyLink": "개인정보 처리방침"
 	}
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -38,5 +38,12 @@
 			"untranslatedTitle": "未翻译",
 			"untranslatedDescription": "尚未翻译。"
 		}
+	},
+	"CookieConsent": {
+		"title": "是否允许 Cookie？",
+		"description": "我们使用 Cookie 来提供并改进 Evame。",
+		"accept": "允许",
+		"decline": "不允许",
+		"privacyLink": "隐私政策"
 	}
 }

--- a/src/app/[locale]/_components/analytics-consent.client.test.tsx
+++ b/src/app/[locale]/_components/analytics-consent.client.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	AnalyticsConsent,
+	analyticsConsentStorageKey,
+} from "./analytics-consent.client";
+
+vi.mock("@next/third-parties/google", () => ({
+	GoogleAnalytics: ({ gaId }: { gaId: string }) => (
+		<div data-ga-id={gaId} data-testid="google-analytics-script" />
+	),
+}));
+
+const message = {
+	title: "Analytics cookies",
+	description: "Allow analytics to improve Evame.",
+	accept: "Accept analytics",
+	decline: "Decline analytics",
+	privacyLink: "Read privacy policy",
+};
+
+describe("AnalyticsConsent", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it("同意未選択ならバナーを表示し、GAタグを読み込まない", async () => {
+		render(
+			<AnalyticsConsent
+				gaTrackingId="G-TEST123"
+				locale="en"
+				message={message}
+			/>,
+		);
+
+		expect(await screen.findByText(message.title)).toBeInTheDocument();
+		expect(
+			screen.queryByTestId("google-analytics-script"),
+		).not.toBeInTheDocument();
+	});
+
+	it("GA ID が未設定でも同意未選択ならバナーを表示する", async () => {
+		render(<AnalyticsConsent gaTrackingId="" locale="en" message={message} />);
+
+		expect(await screen.findByText(message.title)).toBeInTheDocument();
+		expect(
+			screen.queryByTestId("google-analytics-script"),
+		).not.toBeInTheDocument();
+	});
+
+	it("同意済みならGAタグを読み込む", async () => {
+		window.localStorage.setItem(analyticsConsentStorageKey, "accepted");
+
+		render(
+			<AnalyticsConsent
+				gaTrackingId="G-TEST123"
+				locale="en"
+				message={message}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("google-analytics-script")).toBeInTheDocument();
+		});
+		expect(screen.queryByText(message.title)).not.toBeInTheDocument();
+	});
+
+	it("拒否済みならバナーとGAタグを表示しない", async () => {
+		window.localStorage.setItem(analyticsConsentStorageKey, "rejected");
+
+		render(
+			<AnalyticsConsent
+				gaTrackingId="G-TEST123"
+				locale="en"
+				message={message}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.queryByText(message.title)).not.toBeInTheDocument();
+		});
+		expect(
+			screen.queryByTestId("google-analytics-script"),
+		).not.toBeInTheDocument();
+	});
+
+	it("同意するを押すと保存してGAタグを読み込む", async () => {
+		const user = userEvent.setup();
+		render(
+			<AnalyticsConsent
+				gaTrackingId="G-TEST123"
+				locale="en"
+				message={message}
+			/>,
+		);
+
+		await user.click(
+			await screen.findByRole("button", { name: message.accept }),
+		);
+
+		expect(window.localStorage.getItem(analyticsConsentStorageKey)).toBe(
+			"accepted",
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId("google-analytics-script")).toBeInTheDocument();
+		});
+		expect(screen.queryByText(message.title)).not.toBeInTheDocument();
+	});
+
+	it("同意しないを押すと拒否を保存してGAタグを読み込まない", async () => {
+		const user = userEvent.setup();
+		render(
+			<AnalyticsConsent
+				gaTrackingId="G-TEST123"
+				locale="en"
+				message={message}
+			/>,
+		);
+
+		await user.click(
+			await screen.findByRole("button", { name: message.decline }),
+		);
+
+		expect(window.localStorage.getItem(analyticsConsentStorageKey)).toBe(
+			"rejected",
+		);
+		expect(
+			screen.queryByTestId("google-analytics-script"),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(message.title)).not.toBeInTheDocument();
+	});
+});

--- a/src/app/[locale]/_components/analytics-consent.client.tsx
+++ b/src/app/[locale]/_components/analytics-consent.client.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export const analyticsConsentStorageKey = "evame.analytics-consent";
+const analyticsConsentStates = ["accepted", "rejected"] as const;
+type AnalyticsConsentState = (typeof analyticsConsentStates)[number];
+
+export function AnalyticsConsent({
+	gaTrackingId,
+	locale,
+	message,
+}: {
+	gaTrackingId: string;
+	locale: string;
+	message: {
+		title: string;
+		description: string;
+		accept: string;
+		decline: string;
+		privacyLink: string;
+	};
+}) {
+	const [consent, setConsent] = useState<
+		AnalyticsConsentState | null | undefined
+	>(undefined);
+
+	useEffect(() => {
+		const saved = window.localStorage.getItem(analyticsConsentStorageKey);
+		setConsent(
+			analyticsConsentStates.includes(saved as AnalyticsConsentState)
+				? (saved as AnalyticsConsentState)
+				: null,
+		);
+	}, []);
+
+	const handleAccept = () => {
+		window.localStorage.setItem(analyticsConsentStorageKey, "accepted");
+		setConsent("accepted");
+	};
+
+	const handleDecline = () => {
+		window.localStorage.setItem(analyticsConsentStorageKey, "rejected");
+		setConsent("rejected");
+	};
+
+	if (consent === undefined) {
+		return null;
+	}
+
+	return (
+		<>
+			{consent === "accepted" && gaTrackingId && (
+				<GoogleAnalytics gaId={gaTrackingId} />
+			)}
+			{consent === null && (
+				<div className="fixed inset-x-3 bottom-3 z-50 sm:inset-x-auto sm:right-3 sm:w-[420px] md:bottom-5 md:right-5">
+					<section
+						aria-label={message.title}
+						className="rounded-xl border bg-background/95 p-4 shadow-lg backdrop-blur"
+					>
+						<p className="font-semibold text-sm md:text-base">
+							{message.title}
+						</p>
+						<p className="mt-2 text-muted-foreground text-xs md:text-sm">
+							{message.description}{" "}
+							<a className="underline" href={`/${locale}/privacy`}>
+								{message.privacyLink}
+							</a>
+						</p>
+						<div className="mt-3 flex justify-end gap-2">
+							<Button
+								onClick={handleDecline}
+								size="sm"
+								type="button"
+								variant="outline"
+							>
+								{message.decline}
+							</Button>
+							<Button onClick={handleAccept} size="sm" type="button">
+								{message.accept}
+							</Button>
+						</div>
+					</section>
+				</div>
+			)}
+		</>
+	);
+}


### PR DESCRIPTION
## 概要
- クッキー同意バナーを追加し、同意前はGAを読み込まないように変更
- 同意状態を localStorage(`evame.analytics-consent`) に保存
- バナー文言を5ロケール（en/ja/es/ko/zh）に追加
- バナー位置を右下に調整

## 変更点
- `src/app/[locale]/_components/analytics-consent.client.tsx` を新規追加
- `src/app/[locale]/_components/analytics-consent.client.test.tsx` を新規追加
- `src/app/[locale]/layout.tsx` で `GoogleAnalytics` 直描画を廃止し、`AnalyticsConsent` 経由に変更
- `messages/*.json` に `CookieConsent` 文言を追加

## 動作
- 初回未選択: バナー表示、GA未読込
- 許可: 同意保存、GA読込
- 許可しない: 拒否保存、GA未読込
- `GOOGLE_ANALYTICS_ID` 未設定でもバナーは表示（GAは読まない）
- 一度許可してもGAは hydration 後の遅延読み込み

## テスト
- `bunx vitest run --dir "src/app/[locale]/_components"`
- `bun run biome`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * クッキー同意バナーを追加。ユーザーはGoogleアナリティクスの追跡に対して同意または拒否を選択できます。バナーは5言語（英語・スペイン語・日本語・韓国語・中国語）でサポートされ、プライバシーポリシーへのリンクも含まれています。

* **テスト**
  * クッキー同意機能の包括的なテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->