### PR TITLE
トップページのPVをクライアント一括更新に変更

### DIFF
--- a/src/app/[locale]/(common-layout)/_components/page/new-page-list/server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/new-page-list/server.tsx
@@ -38,6 +38,9 @@ export default async function NewPageList({
 				pageSize: 5,
 				locale,
 			});
+	const liveViewCountPageIds = showPagination
+		? undefined
+		: pageForLists.map((pageForList) => pageForList.id);
 
 	return (
 		<PageListContainer icon={SparklesIcon} title="New Pages">
@@ -46,6 +49,7 @@ export default async function NewPageList({
 				<PageList
 					index={index}
 					key={PageForList.id}
+					liveViewCountPageIds={liveViewCountPageIds}
 					locale={locale}
 					PageForList={PageForList}
 				/>

--- a/src/app/[locale]/(common-layout)/_components/page/page-list.server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/page-list.server.tsx
@@ -9,12 +9,14 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Link } from "@/i18n/routing";
 import { PageActionsDropdown } from "./page-actions-dropdown/client";
 import { PageCommentButton } from "./page-list/page-comment-button.client";
+import { PageViewCount } from "./page-view-count.client";
 
 type PageListProps = {
 	PageForList: PageForList;
 	showOwnerActions?: boolean;
 	index?: number;
 	locale: string;
+	liveViewCountPageIds?: number[];
 };
 
 export async function PageList({
@@ -22,6 +24,7 @@ export async function PageList({
 	showOwnerActions = false,
 	index,
 	locale,
+	liveViewCountPageIds,
 }: PageListProps) {
 	const { props } = getImageProps({
 		src: PageForList.userImage,
@@ -98,7 +101,11 @@ export async function PageList({
 				{/* ③ アクション（いいね＋コメント） */}
 				<div className="flex items-center gap-2 justify-end">
 					<EyeIcon className="w-5 h-5" />
-					<span className="text-muted-foreground">{PageForList.viewCount}</span>
+					<PageViewCount
+						batchPageIds={liveViewCountPageIds}
+						initialCount={PageForList.viewCount}
+						pageId={PageForList.id}
+					/>
 					<PageLikeButton
 						initialLikeCount={PageForList.likeCount}
 						pageId={PageForList.id}

--- a/src/app/[locale]/(common-layout)/_components/page/page-view-count.client.test.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/page-view-count.client.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PageViewCount } from "./page-view-count.client";
+
+describe("PageViewCount", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("初期値を表示し、API応答後に最新の閲覧数へ更新する", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				counts: { 10: 42, 11: 7 },
+			}),
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		render(
+			<PageViewCount batchPageIds={[10, 11]} initialCount={1} pageId={10} />,
+		);
+
+		expect(screen.getByText("1")).toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(screen.getByText("42")).toBeInTheDocument();
+		});
+		expect(fetchMock).toHaveBeenCalledWith("/api/page-views?ids=10,11");
+	});
+
+	it("batchPageIdsがない場合はAPIを呼ばず初期値を表示する", () => {
+		const fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		render(<PageViewCount initialCount={9} pageId={10} />);
+
+		expect(screen.getByText("9")).toBeInTheDocument();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/[locale]/(common-layout)/_components/page/page-view-count.client.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/page-view-count.client.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import useSWR from "swr";
+
+type PageViewCountProps = {
+	pageId: number;
+	initialCount: number;
+	className?: string;
+	batchPageIds?: number[];
+};
+
+type PageViewCountsResponse = {
+	counts: Record<string, number>;
+};
+
+function buildQueryKey(batchPageIds: number[] | undefined): string | null {
+	if (!batchPageIds || batchPageIds.length === 0) {
+		return null;
+	}
+
+	const ids = Array.from(
+		new Set(batchPageIds.filter((id) => Number.isInteger(id) && id > 0)),
+	).sort((a, b) => a - b);
+
+	if (ids.length === 0) {
+		return null;
+	}
+
+	return `/api/page-views?ids=${ids.join(",")}`;
+}
+
+export function PageViewCount({
+	pageId,
+	initialCount,
+	className = "text-muted-foreground",
+	batchPageIds,
+}: PageViewCountProps) {
+	const { data } = useSWR<PageViewCountsResponse>(
+		buildQueryKey(batchPageIds),
+		(url) =>
+			fetch(url)
+				.then((response) => {
+					if (!response.ok) {
+						throw new Error("failed to fetch page views");
+					}
+					return response.json() as Promise<PageViewCountsResponse>;
+				})
+				.catch(() => ({ counts: {} })),
+		{
+			revalidateOnFocus: false,
+			revalidateOnReconnect: false,
+			refreshInterval: 0,
+		},
+	);
+
+	const nextCount = data?.counts?.[String(pageId)];
+	const count = typeof nextCount === "number" ? nextCount : initialCount;
+
+	return <span className={className}>{count}</span>;
+}

--- a/src/app/[locale]/(common-layout)/_components/page/popular-page-list/server.tsx
+++ b/src/app/[locale]/(common-layout)/_components/page/popular-page-list/server.tsx
@@ -38,6 +38,9 @@ export default async function PopularPageList({
 				pageSize: 5,
 				locale,
 			});
+	const liveViewCountPageIds = showPagination
+		? undefined
+		: pageForLists.map((pageForList) => pageForList.id);
 
 	return (
 		<PageListContainer icon={BookOpenIcon} title="Popular Pages">
@@ -46,6 +49,7 @@ export default async function PopularPageList({
 				<PageList
 					index={index}
 					key={PageForList.id}
+					liveViewCountPageIds={liveViewCountPageIds}
 					locale={locale}
 					PageForList={PageForList}
 				/>

--- a/src/app/api/page-views/route.test.ts
+++ b/src/app/api/page-views/route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const selectFromMock = vi.fn();
+const selectMock = vi.fn();
+const whereMock = vi.fn();
+const executeMock = vi.fn();
+
+vi.mock("@/db", () => ({
+	db: {
+		selectFrom: selectFromMock,
+	},
+}));
+
+selectFromMock.mockImplementation(() => ({
+	select: selectMock,
+}));
+selectMock.mockImplementation(() => ({
+	where: whereMock,
+}));
+whereMock.mockImplementation(() => ({
+	execute: executeMock,
+}));
+const { GET } = await import("./route");
+
+describe("GET /api/page-views", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		executeMock.mockResolvedValue([]);
+	});
+
+	it("指定したページID群の閲覧数を返し未登録ページは0を返す", async () => {
+		executeMock.mockResolvedValue([{ pageId: 10, count: 12 }]);
+
+		const response = await GET(
+			new Request("http://localhost/api/page-views?ids=10,11"),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({
+			counts: {
+				10: 12,
+				11: 0,
+			},
+		});
+		expect(selectFromMock).toHaveBeenCalledWith("pageViews");
+		expect(whereMock).toHaveBeenCalledWith("pageId", "in", [10, 11]);
+	});
+
+	it("idsが未指定なら400を返す", async () => {
+		const response = await GET(new Request("http://localhost/api/page-views"));
+		expect(response.status).toBe(400);
+		expect(selectFromMock).not.toHaveBeenCalled();
+	});
+
+	it("idsが数値でない場合は400を返す", async () => {
+		const response = await GET(
+			new Request("http://localhost/api/page-views?ids=abc,def"),
+		);
+		expect(response.status).toBe(400);
+		expect(selectFromMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/api/page-views/route.ts
+++ b/src/app/api/page-views/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+
+function parsePageIds(idsParam: string | null): number[] | null {
+	if (!idsParam) {
+		return null;
+	}
+
+	const ids = Array.from(
+		new Set(
+			idsParam
+				.split(",")
+				.map((id) => Number(id.trim()))
+				.filter((id) => Number.isInteger(id) && id > 0),
+		),
+	);
+
+	if (ids.length === 0) {
+		return null;
+	}
+
+	return ids;
+}
+
+export async function GET(request: Request) {
+	const pageIds = parsePageIds(new URL(request.url).searchParams.get("ids"));
+	if (!pageIds) {
+		return NextResponse.json(
+			{ error: "ids query parameter is required" },
+			{ status: 400 },
+		);
+	}
+
+	const rows = await db
+		.selectFrom("pageViews")
+		.select(["pageId", "count"])
+		.where("pageId", "in", pageIds)
+		.execute();
+
+	const countByPageId = new Map(rows.map((row) => [row.pageId, row.count]));
+	const counts = Object.fromEntries(
+		pageIds.map((pageId) => [pageId, countByPageId.get(pageId) ?? 0]),
+	);
+
+	return NextResponse.json({ counts });
+}


### PR DESCRIPTION
## 概要
トップページの New/Popular 一覧で、ページビュー表示が12時間キャッシュに引きずられて更新されない問題を解消しました。

## 変更内容
- `GET /api/page-views?ids=...` を追加し、複数ページのPVを一括取得可能にしました
- `PageViewCount` クライアントコンポーネントを追加し、一覧のPV表示をAPI結果で上書き更新するようにしました
- `PageList` に `liveViewCountPageIds` を追加し、トップページの New/Popular 一覧（`showPagination=false`）のみライブPV更新を有効化しました
- 既存の詳細ページPVインクリメントAPI (`/api/page-views/[pageId]/increment`) は変更していません

## テスト
- `bun run test src/app/api/page-views/route.test.ts src/app/[locale]/(common-layout)/_components/page/page-view-count.client.test.tsx`
- `bun run typecheck`
- `bun run biome`

## 補足
- `bun run test` 全体は、既存のDB統合テスト群が `test_neon` コンテナ未起動で失敗するためローカル完走していません（今回変更とは無関係）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ページビューカウント機能を追加。ページリストにおいてページ表示回数がリアルタイムで更新・表示されるようになりました。

* **テスト**
  * ページビューカウント機能の単体テストとAPI統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->